### PR TITLE
Added missing keyword argument for settings

### DIFF
--- a/phono3py/cui/phono3py_yaml.py
+++ b/phono3py/cui/phono3py_yaml.py
@@ -40,7 +40,8 @@ class Phono3pyYaml(PhonopyYaml):
     def __init__(self,
                  configuration=None,
                  calculator=None,
-                 physical_units=None):
+                 physical_units=None,
+                 settings=None):
         self.configuration = None
         self.calculator = None
         self.physical_units = None


### PR DESCRIPTION
The missing settings argument causes the following error when saving a Phono3py object (which I've called 'phonon'):

```
>>> phonon.save()
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "/users/fjbh500/.conda/envs/phonopy/lib/python3.8/site-packages/phono3py/api_phono3py.py", line 1216, in save
ph3py_yaml = Phono3pyYaml(settings=settings)
TypeError: __init__() got an unexpected keyword argument 'settings' 
```

This change fixes it, and a Phono3pyYaml object is successfully created by Phono3py.save().