### PR TITLE
Pass `compression` keyword argument

### DIFF
--- a/phono3py/phonon3/conductivity_RTA.py
+++ b/phono3py/phonon3/conductivity_RTA.py
@@ -263,6 +263,7 @@ def _write_gamma(br, interaction, i, compression="gzip", filename=None,
                     sigma=sigma,
                     sigma_cutoff=sigma_cutoff,
                     kappa_unit_conversion=unit_to_WmK / volume,
+                    compression=compression,
                     filename=filename,
                     verbose=verbose)
 


### PR DESCRIPTION
Fix a missing `compression` keyword argument for `write_kappa_to_hdf5` in `_write_gamma` function.
This keyword should be passed in all code paths to allow the `--hdf-compression` option to be honoured.