### PR TITLE
enh: major refactoring of setup.py

### DIFF
--- a/c/_phono3py.c
+++ b/c/_phono3py.c
@@ -1729,7 +1729,7 @@ static PyObject *py_get_default_colmat_solver(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-#ifdef MKL_LAPACKE
+#if defined(MKL_LAPACKE) || defined(SCIPY_MKL_H)
     return PyLong_FromLong((long)1);
 #else
     return PyLong_FromLong((long)4);
@@ -1749,7 +1749,7 @@ static void pinv_from_eigensolution(double *data, const double *eigvals,
 
     tmp_data = (double *)malloc(sizeof(double) * size * size);
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (i = 0; i < size * size; i++) {
@@ -1770,7 +1770,7 @@ static void pinv_from_eigensolution(double *data, const double *eigvals,
         }
     }
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(ib, j, k, i_s, j_s, sum)
 #endif
     for (i = 0; i < size / 2; i++) {

--- a/c/collision_matrix.c
+++ b/c/collision_matrix.c
@@ -117,7 +117,7 @@ static void get_collision_matrix(
 
     gp2tp_map = create_gp2tp_map(triplets_map, num_gp);
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, k, l, m, n, ti, r_gp, collision, inv_sinh)
 #endif
     for (i = 0; i < num_ir_gp; i++) {
@@ -186,7 +186,7 @@ static void get_reducible_collision_matrix(
 
     gp2tp_map = create_gp2tp_map(triplets_map, num_gp);
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, k, l, ti, collision, inv_sinh)
 #endif
     for (i = 0; i < num_gp; i++) {

--- a/c/dynmat.c
+++ b/c/dynmat.c
@@ -75,7 +75,7 @@ long dym_get_dynamical_matrix_at_q(double *dynamical_matrix,
     long i, j, ij;
 
     if (with_openmp) {
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
         for (ij = 0; ij < num_patom * num_patom; ij++) {

--- a/c/fc3.c
+++ b/c/fc3.c
@@ -124,7 +124,7 @@ void fc3_set_permutation_symmetry_fc3(double *fc3, const long num_atom) {
     double fc3_elem[27];
     long i, j, k;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, k, fc3_elem)
 #endif
     for (i = 0; i < num_atom; i++) {

--- a/c/imag_self_energy_with_g.c
+++ b/c/imag_self_energy_with_g.c
@@ -99,7 +99,7 @@ void ise_get_imag_self_energy_at_bands_with_g(
         g_index_shift = frequency_point_index * num_band * num_band;
     }
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(num_g_pos, j, g_pos)
 #endif
     for (i = 0; i < num_triplets; i++) {
@@ -167,7 +167,7 @@ void ise_get_detailed_imag_self_energy_at_bands_with_g(
 
     /* detailed_imag_self_energy has the same shape as fc3_normal_squared. */
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (i = 0; i < num_triplets; i++) {
@@ -187,7 +187,7 @@ void ise_get_detailed_imag_self_energy_at_bands_with_g(
     for (i = 0; i < num_band0; i++) {
         N = 0;
         U = 0;
-        /* #ifdef PHPYOPENMP */
+        /* #ifdef _OPENMP */
         /* #pragma omp parallel for private(ise_tmp) reduction(+:N,U) */
         /* #endif */
         for (j = 0; j < num_triplets; j++) {

--- a/c/interaction.c
+++ b/c/interaction.c
@@ -99,7 +99,7 @@ void itr_get_interaction(Darray *fc3_normal_squared, const char *g_zero,
         openmp_per_triplets = 0;
     }
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for schedule(guided) private( \
     num_g_pos, g_pos) if (openmp_per_triplets)
 #endif

--- a/c/isotope.c
+++ b/c/isotope.c
@@ -73,7 +73,7 @@ void iso_get_isotope_scattering_strength(
             continue;
         }
         sum_g = 0;
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(k, l, m, f, e1_r, e1_i, a, b, dist, sum_g_k) reduction(+ \
                                                                                         : sum_g)
 #endif
@@ -151,14 +151,14 @@ void iso_get_thm_isotope_scattering_strength(
     }
 
     gamma_ij = (double *)malloc(sizeof(double) * num_grid_points * num_band0);
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (i = 0; i < num_grid_points * num_band0; i++) {
         gamma_ij[i] = 0;
     }
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, k, l, m, f, gp, e1_r, e1_i, a, b, dist, \
                                  sum_g_k)
 #endif

--- a/c/lapack_wrapper.c
+++ b/c/lapack_wrapper.c
@@ -36,7 +36,7 @@
 
 #define min(a, b) ((a) > (b) ? (b) : (a))
 
-#ifdef MKL_LAPACKE
+#if defined(MKL_LAPACKE) || defined(SCIPY_MKL_H)
 MKL_Complex16 lapack_make_complex_double(double re, double im) {
     MKL_Complex16 z;
     z.real = re;
@@ -108,7 +108,7 @@ void phonopy_pinv_mt(double *data_out, int *info_out, const double *data_in,
                      const double cutoff) {
     int i;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (i = 0; i < num_thread; i++) {

--- a/c/lapack_wrapper.h
+++ b/c/lapack_wrapper.h
@@ -35,7 +35,7 @@
 #ifndef __lapack_wrapper_H__
 #define __lapack_wrapper_H__
 
-#ifdef MKL_LAPACKE
+#if defined(MKL_LAPACKE) || defined(SCIPY_MKL_H)
 #include <mkl.h>
 #define lapack_complex_double MKL_Complex16
 #define lapack_complex_double_real(z) ((z).real)

--- a/c/phono3py.c
+++ b/c/phono3py.c
@@ -531,7 +531,7 @@ void ph3py_symmetrize_collision_matrix(double *collision_matrix,
             adrs_shift = (i * num_column * num_column * num_temp +
                           j * num_column * num_column);
             /* show_colmat_info(py_collision_matrix, i, j, adrs_shift); */
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for schedule(guided) private(l, val)
 #endif
             for (k = 0; k < num_column; k++) {
@@ -567,7 +567,7 @@ void ph3py_expand_collision_matrix(double *collision_matrix,
     num_column = num_grid_points * num_band;
     num_bgb = num_band * num_grid_points * num_band;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for schedule(guided) private(j, ir_gp)
 #endif
     for (i = 0; i < num_ir_gp; i++) {
@@ -584,7 +584,7 @@ void ph3py_expand_collision_matrix(double *collision_matrix,
         for (j = 0; j < num_temp; j++) {
             adrs_shift = (i * num_column * num_column * num_temp +
                           j * num_column * num_column);
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(ir_gp, adrs_shift_plus, colmat_copy, l, gp_r, \
                                  m, n, p)
 #endif
@@ -650,7 +650,7 @@ long ph3py_get_neighboring_gird_points(
         bzgrid->D_diag[i] = D_diag[i];
     }
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (i = 0; i < num_grid_points; i++) {
@@ -695,7 +695,7 @@ long ph3py_get_thm_integration_weights_at_grid_points(
         bzgrid->D_diag[i] = D_diag[i];
     }
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, k, bi, vertices, freq_vertices)
 #endif
     for (i = 0; i < num_gp; i++) {

--- a/c/phono3py.h
+++ b/c/phono3py.h
@@ -35,7 +35,7 @@
 #ifndef __phono3py_H__
 #define __phono3py_H__
 
-#ifdef MKL_LAPACKE
+#if defined(MKL_LAPACKE) || defined(SCIPY_MKL_H)
 #include <mkl.h>
 #else
 #include <lapacke.h>

--- a/c/phonon.c
+++ b/c/phonon.c
@@ -195,7 +195,7 @@ static void get_undone_phonons(
 
     num_band = num_patom * 3;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, q, gp, is_nac)
 #endif
     for (i = 0; i < num_undone_grid_points; i++) {
@@ -214,7 +214,7 @@ static void get_undone_phonons(
     }
 
 /* To avoid multithreaded BLAS in OpenMP loop */
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #ifndef MULTITHREADED_BLAS
 #pragma omp parallel for private(j, gp, freqs_tmp, info)
 #endif
@@ -255,7 +255,7 @@ static void get_gonze_undone_phonons(
 
     num_band = num_patom * 3;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, q, gp, is_nac)
 #endif
     for (i = 0; i < num_undone_grid_points; i++) {
@@ -274,7 +274,7 @@ static void get_gonze_undone_phonons(
     }
 
 /* To avoid multithreaded BLAS in OpenMP loop */
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #ifndef MULTITHREADED_BLAS
 #pragma omp parallel for private(j, gp, freqs_tmp, info)
 #endif

--- a/c/pp_collision.c
+++ b/c/pp_collision.c
@@ -106,7 +106,7 @@ void ppc_get_pp_collision(
     tpl_set_relative_grid_address(tp_relative_grid_address,
                                   relative_grid_address, 2);
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for schedule(guided) private( \
     g, g_zero) if (openmp_per_triplets)
 #endif
@@ -186,7 +186,7 @@ void ppc_get_pp_collision_with_sigma(
 
     cutoff = sigma * sigma_cutoff;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for schedule(guided) private( \
     g, g_zero) if (openmp_per_triplets)
 #endif

--- a/c/real_self_energy.c
+++ b/c/real_self_energy.c
@@ -118,7 +118,7 @@ static double get_real_self_energy_at_band(
     num_band = fc3_normal_squared->dims[2];
 
     shift = 0;
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(gp1, gp2) reduction(+ : shift)
 #endif
     for (i = 0; i < num_triplets; i++) {

--- a/c/real_to_reciprocal.c
+++ b/c/real_to_reciprocal.c
@@ -138,7 +138,7 @@ static void real_to_reciprocal_openmp(
     for (i = 0; i < num_patom; i++) {
         pre_phase_factor = get_pre_phase_factor(i, q_vecs, svecs, multi_dims,
                                                 multiplicity, p2s_map);
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, k, l, m, n, fc3_rec_elem)
 #endif
         for (jk = 0; jk < num_patom * num_patom; jk++) {

--- a/c/reciprocal_to_normal.c
+++ b/c/reciprocal_to_normal.c
@@ -114,7 +114,7 @@ void reciprocal_to_normal_squared(
     loopStartCPUTime = clock();
 #endif
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for if (openmp_at_bands)
 #endif
     for (i = 0; i < num_g_pos; i++) {

--- a/c/triplet.c
+++ b/c/triplet.c
@@ -72,7 +72,7 @@ void tpl_get_integration_weight(
                                   relative_grid_address, tp_type);
     num_band_prod = num_band0 * num_band1 * num_band2;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for if (openmp_per_triplets)
 #endif
     for (i = 0; i < num_triplets; i++) {
@@ -98,7 +98,7 @@ void tpl_get_integration_weight_with_sigma(
     num_band_prod = num_band0 * num_band * num_band;
     const_adrs_shift = num_triplets * num_band0 * num_band * num_band;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (i = 0; i < num_triplets; i++) {

--- a/c/triplet_grid.c
+++ b/c/triplet_grid.c
@@ -158,7 +158,7 @@ static long get_ir_triplets_at_q_perm_q1q2(long *map_triplets,
     num_grid = D_diag[0] * D_diag[1] * D_diag[2];
     grg_get_grid_address_from_index(adrs0, grid_point, D_diag);
 
-    // #ifdef PHPYOPENMP
+    // #ifdef _OPENMP
     // #pragma omp parallel for private(j, gp2, adrs1, adrs2)
     // #endif
     for (gp1 = 0; gp1 < num_grid; gp1++) {
@@ -181,7 +181,7 @@ static long get_ir_triplets_at_q_perm_q1q2(long *map_triplets,
     }
 
 /* Fill unfilled elements of map_triplets. */
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (gp1 = 0; gp1 < num_grid; gp1++) {
@@ -275,7 +275,7 @@ static void get_BZ_triplets_at_q_type1(long (*triplets)[3],
     num_gp = bzgrid->D_diag[0] * bzgrid->D_diag[1] * bzgrid->D_diag[2];
     num_bzgp = num_gp * 8;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, gp2, bzgp, G, bz_adrs1, bz_adrs2, d2, \
                                  min_d2, bz0, bz1, bz2)
 #endif
@@ -360,7 +360,7 @@ static void get_BZ_triplets_at_q_type2(long (*triplets)[3],
     }
     gp0 = grg_get_grid_index(bz_adrs0, bzgrid->D_diag);
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, gp2, bzgp, G, bz_adrs1, bz_adrs2, d2, \
                                  min_d2)
 #endif

--- a/c/triplet_iw.c
+++ b/c/triplet_iw.c
@@ -96,7 +96,7 @@ void tpi_get_integration_weight(
         max_i = 1;
     }
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, b1, b2, adrs_shift, g, \
                                  freq_vertices) if (openmp_per_bands)
 #endif
@@ -136,7 +136,7 @@ void tpi_get_integration_weight_with_sigma(
     long j, b12, b1, b2, adrs_shift;
     double f0, f1, f2, g0, g1, g2;
 
-#ifdef PHPYOPENMP
+#ifdef _OPENMP
 #pragma omp parallel for private(j, b1, b2, f0, f1, f2, g0, g1, g2, \
                                  adrs_shift) if (openmp_per_bands)
 #endif

--- a/doc/install.md
+++ b/doc/install.md
@@ -56,6 +56,19 @@ Ubuntu linux, it is installed by:
    % sudo apt-get install libgomp1
 ```
 
+
+Users mays customize flags and additional libraries by adding a `site.cfg`
+that conforms to numpy stile distutils (`numpy.distutils.site.cfg` file).
+A basic example to add include directories and openmp flags would be:
+
+```
+[phono3py]
+include_dirs = /opt/lapack/include
+extra_compile_args = -fopenmp
+extra_link_args = -fopenmp
+```
+
+
 (install_lapacke)=
 ### Installation of LAPACKE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy"]
+requires = ["setuptools", "wheel", "numpy", "oldest-supported-numpy"]
+
+[project]
+requires-python = ">=3.6"
 
 [tool.flake8]
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -4,32 +4,34 @@ import platform
 import sys
 import sysconfig
 
+import numpy
+
 # Never use distutils, it is deprecated
 import setuptools
-
-import numpy
 
 git_num = None
 
 # Retrieve the default flags from the numpy installation
 # This also means one can override this with a site.cfg
 # configuration file
-from numpy.distutils.system_info import system_info, get_info, lapack_info, dict_append
+from numpy.distutils.system_info import dict_append, get_info, lapack_info, system_info
 
 # use flags defined in numpy
-all_info_d = get_info('ALL')
-lapack_info_d = get_info('lapack_opt')
+all_info_d = get_info("ALL")
+lapack_info_d = get_info("lapack_opt")
+
 
 class phono3py_info(system_info):
-    # This enables one 
+    # This enables one
     section = "phono3py"
 
     def calc_info(self):
-        """ Read in *all* options in the [phono3py] section of site.cfg """
+        """Read in *all* options in the [phono3py] section of site.cfg"""
         info = self.calc_libraries_info()
         dict_append(info, **self.calc_extra_info())
         dict_append(info, include_dirs=self.get_include_dirs())
         self.set_info(**info)
+
 
 # Define compilation flags
 extra_compile_args = ""
@@ -71,7 +73,7 @@ if with_threaded_blas:
 
 # Create the dictionary for compiling the codes
 dict_append(opts, **all_info_d)
-dict_append(opts, include_dirs=['c'])
+dict_append(opts, include_dirs=["c"])
 dict_append(opts, define_macros=macros)
 # Add numpy's headers
 include_dirs = numpy.get_include()
@@ -109,10 +111,9 @@ sources_phono3py = [
     "c/triplet_grid.c",
     "c/triplet_iw.c",
 ]
-extensions.append(setuptools.Extension(
-    "phono3py._phono3py",
-    sources=sources_phono3py,
-    **opts))
+extensions.append(
+    setuptools.Extension("phono3py._phono3py", sources=sources_phono3py, **opts)
+)
 
 
 sources_phononmod = [
@@ -122,16 +123,14 @@ sources_phononmod = [
     "c/phonon.c",
     "c/phononmod.c",
 ]
-extensions.append(setuptools.Extension(
-    "phono3py._phononmod",
-    sources=sources_phononmod,
-    **opts))
+extensions.append(
+    setuptools.Extension("phono3py._phononmod", sources=sources_phononmod, **opts)
+)
 
 sources_lapackepy = ["c/_lapackepy.c", "c/lapack_wrapper.c"]
-extensions.append(setuptools.Extension(
-    "phono3py._lapackepy",
-    sources=sources_lapackepy,
-    **opts))
+extensions.append(
+    setuptools.Extension("phono3py._lapackepy", sources=sources_lapackepy, **opts)
+)
 
 packages_phono3py = [
     "phono3py",
@@ -202,5 +201,5 @@ if __name__ == "__main__":
         ],
         provides=["phono3py"],
         scripts=scripts_phono3py,
-        ext_modules=extensions
+        ext_modules=extensions,
     )

--- a/setup.py
+++ b/setup.py
@@ -4,257 +4,88 @@ import platform
 import sys
 import sysconfig
 
+# Never use distutils, it is deprecated
+import setuptools
+
 import numpy
 
-try:
-    from setuptools import Extension, setup
+git_num = None
 
-    use_setuptools = True
-    print("setuptools is used.")
-except ImportError:
-    from distutils.core import Extension, setup
+# Retrieve the default flags from the numpy installation
+# This also means one can override this with a site.cfg
+# configuration file
+from numpy.distutils.system_info import system_info, get_info, lapack_info, dict_append
 
-    use_setuptools = False
-    print("distutils is used.")
+# use flags defined in numpy
+all_info_d = get_info('ALL')
+lapack_info_d = get_info('lapack_opt')
 
-try:
-    from setuptools_scm import get_version
-except ImportError:
-    git_num = None
+class phono3py_info(system_info):
+    # This enables one 
+    section = "phono3py"
 
-if "setuptools_scm" in sys.modules.keys():
-    try:
-        git_ver = get_version()
-        git_num = int(git_ver.split(".")[3].split("+")[0].replace("dev", ""))
-    except Exception:
-        git_num = None
+    def calc_info(self):
+        """ Read in *all* options in the [phono3py] section of site.cfg """
+        info = self.calc_libraries_info()
+        dict_append(info, **self.calc_extra_info())
+        dict_append(info, include_dirs=self.get_include_dirs())
+        self.set_info(**info)
 
-include_dirs_numpy = [numpy.get_include()]
-extra_link_args = []
-# Workaround Python issue 21121
-config_var = sysconfig.get_config_var("CFLAGS")
-if (
-    config_var is not None and "-Werror=declaration-after-statement" in config_var
-):  # noqa E129
-    os.environ["CFLAGS"] = config_var.replace("-Werror=declaration-after-statement", "")
+# Define compilation flags
+extra_compile_args = ""
+extra_link_args = extra_compile_args
+macros = []
 
-extra_compile_args = [
-    "-fopenmp",
-]
-include_dirs = [
-    "c",
-] + include_dirs_numpy
-define_macros = []
-
-if use_setuptools:
-    extra_compile_args += [
-        "-DPHPYOPENMP",
-    ]
-else:
-    define_macros += [
-        ("PHPYOPENMP", None),
-    ]
+# in numpy>=1.16.0, silence build warnings about deprecated API usage
+macros.append(("NPY_NO_DEPRECATED_API", "0"))
 
 
-use_mkl = False
-include_dirs_lapacke = []
-extra_link_args_lapacke = []
-# C macro definitions:
-# - MULTITHREADED_BLAS
-#   This deactivates OpenMP multithread harmonic phonon calculation,
-#   since inside each phonon calculation, zheev is called.
-#   When using multithread BLAS, this macro has to be set and
-#   by this all phonons on q-points should be calculated in series.
-# - MKL_LAPACKE:
-#   This sets definitions and functions needed when using MKL lapacke.
-#   Phono3py complex values are handled based on those provided by Netlib
-#   lapacke. However MKL lapacke doesn't provide some macros and functions
-#   that provided Netlib. This macro defines those used in phono3py among them.
-if os.path.isfile("setup_mkl.py"):
-    # This supposes that MKL multithread BLAS is used.
-    # This is invoked when setup_mkl.py exists on the current directory.
+with_threaded_blas = False
+if "--with-threaded-blas" in sys.argv:
+    del sys.argv["--with-threaded-blas"]
+    with_threaded_blas = True
 
-    print("MKL LAPACKE is to be used.")
-    print("Use of icc is assumed (CC='icc').")
+with_mkl = False
+if "--with-mkl" in sys.argv:
+    del sys.argv["--with-mkl"]
+    with_mkl = True
+    # MKL generally uses multi-threaded blas
+    with_threaded_blas = True
 
-    from setup_mkl import mkl_extra_link_args_lapacke, mkl_include_dirs_lapacke
 
-    # Examples of setup_mkl.py
-    # For 2015
-    # intel_root = "/opt/intel/composer_xe_2015.7.235"
-    # mkl_root = "%s/mkl" % intel_root
-    # compiler_root = "%s/compiler" % intel_root
-    #
-    # For 2016
-    # intel_root = "/opt/intel/parallel_studio_xe_2016"
-    # mkl_root = "%s/mkl" % intel_root
-    # compiler_root = "%s" % intel_root
-    #
-    # For both
-    # mkl_extra_link_args_lapacke = ['-L%s/lib/intel64' % mkl_root,
-    #                                '-lmkl_rt']
-    # mkl_extra_link_args_lapacke += ['-L%s/lib/intel64' % compiler_root,
-    #                                 '-lsvml',
-    #                                 '-liomp5',
-    #                                 '-limf',
-    #                                 '-lpthread']
-    # mkl_include_dirs_lapacke = ["%s/include" % mkl_root]
+# define options
+# these are the basic definitions for all extensions
+opts = lapack_info_d.copy()
+if "mkl" in opts.get("libraries", ""):
+    with_mkl = True
 
-    use_mkl = True
-    extra_link_args_lapacke = mkl_extra_link_args_lapacke
-    include_dirs_lapacke = mkl_include_dirs_lapacke
+if with_mkl:
+    with_threaded_blas = True
+    # generally this should not be needed since the numpy distutils
+    # finding of MKL creates the SCIPY_MKL_H flag
+    macros.append(("MKL_LAPACKE", None))
 
-    if use_setuptools:
-        extra_compile_args += ["-DMKL_LAPACKE", "-DMULTITHREADED_BLAS"]
-    else:
-        define_macros += [("MKL_LAPACKE", None), ("MULTITHREADED_BLAS", None)]
-elif os.path.isfile("libopenblas.py"):
-    # This supposes that multithread openBLAS is used.
-    # This is invoked when libopenblas.py exists on the current directory.
+if with_threaded_blas:
+    macros.append(("MULTITHREADED_BLAS", None))
 
-    # Example of libopenblas.py
-    # extra_link_args_lapacke += ['-lopenblas']
 
-    from libopenblas import extra_link_args_lapacke as obl_extra_link_args_lapacke
-    from libopenblas import include_dirs_lapacke as obl_include_dirs_lapacke
+# Create the dictionary for compiling the codes
+dict_append(opts, **all_info_d)
+dict_append(opts, include_dirs=['c'])
+dict_append(opts, define_macros=macros)
+# Add numpy's headers
+include_dirs = numpy.get_include()
+if include_dirs is not None:
+    dict_append(opts, include_dirs=[include_dirs])
 
-    extra_link_args_lapacke = obl_extra_link_args_lapacke
-    include_dirs_lapacke = obl_include_dirs_lapacke
+# Add any phono3py manual flags from here
+add_opts = phono3py_info().get_info()
+dict_append(opts, **add_opts)
 
-    if use_setuptools:
-        extra_compile_args += ["-DMULTITHREADED_BLAS"]
-    else:
-        define_macros += [("MULTITHREADED_BLAS", None)]
-elif platform.system() == "Darwin" and os.path.isfile("/opt/local/lib/libopenblas.a"):
-    # This supposes lapacke with single-thread openBLAS provided by MacPort is
-    # used.
-    # % sudo port install gcc6
-    # % sudo port select --set gcc mp-gcc
-    # % sudo port install OpenBLAS +gcc6
-    extra_link_args_lapacke = ["/opt/local/lib/libopenblas.a"]
-    include_dirs_lapacke = ["/opt/local/include"]
-elif "CONDA_PREFIX" in os.environ and (
-    os.path.isfile(os.path.join(os.environ["CONDA_PREFIX"], "lib", "liblapacke.dylib"))
-    or os.path.isfile(os.path.join(os.environ["CONDA_PREFIX"], "lib", "liblapacke.so"))
-):
-    # This is for the system prepared with conda openblas.
-    extra_link_args_lapacke = ["-llapacke"]
-    include_dirs_lapacke = [
-        os.path.join(os.environ["CONDA_PREFIX"], "include"),
-    ]
-    if os.path.isfile(os.path.join(os.environ["CONDA_PREFIX"], "include", "mkl.h")):
-        use_mkl = True
-        if use_setuptools:
-            extra_compile_args += ["-DMKL_LAPACKE", "-DMULTITHREADED_BLAS"]
-        else:
-            define_macros += [("MKL_LAPACKE", None), ("MULTITHREADED_BLAS", None)]
-    else:
-        if use_setuptools:
-            extra_compile_args += ["-DMULTITHREADED_BLAS"]
-        else:
-            define_macros += [("MULTITHREADED_BLAS", None)]
-elif (
-    "CONDA_PREFIX" in os.environ
-    and (
-        os.path.isfile(
-            os.path.join(os.environ["CONDA_PREFIX"], "lib", "libmkl_rt.dylib")
-        )
-        or os.path.isfile(
-            os.path.join(os.environ["CONDA_PREFIX"], "lib", "libmkl_rt.so")
-        )
-    )
-    and (
-        os.path.isfile(
-            os.path.join(os.environ["CONDA_PREFIX"], "include", "mkl_lapacke.h")
-        )
-    )
-):
-    include_dirs_lapacke = [
-        os.path.join(os.environ["CONDA_PREFIX"], "include"),
-    ]
-    extra_link_args_lapacke = ["-lmkl_rt"]
-    if use_setuptools:
-        extra_compile_args += ["-DMKL_LAPACKE", "-DMULTITHREADED_BLAS"]
-    else:
-        define_macros += [("MKL_LAPACKE", None), ("MULTITHREADED_BLAS", None)]
-elif os.path.isfile("/usr/lib/liblapacke.so"):
-    # This supposes that lapacke with single-thread BLAS is installed on
-    # system.
-    extra_link_args_lapacke = ["-llapacke", "-llapack", "-lblas"]
-    include_dirs_lapacke = []
-else:
-    # Here is the default lapacke linkage setting.
-    # Please modify according to your system environment.
-    # Without using multithreaded BLAS, DMULTITHREADED_BLAS is better to be
-    # removed to activate OpenMP multithreading harmonic phonon calculation,
-    # but this is not mandatory.
-    #
-    # The below supposes that lapacke with multithread openblas is used.
-    # Even if using single-thread BLAS and deactivating OpenMP
-    # multithreading for harmonic phonon calculation, the total performance
-    # decrease is considered marginal.
-    #
-    # For conda: Try installing with dynamic link library of openblas by
-    # % conda install numpy scipy h5py pyyaml matplotlib openblas libgfortran
-    extra_link_args_lapacke = ["-lopenblas", "-lgfortran"]
-    if "CONDA_PREFIX" in os.environ:
-        include_dirs_lapacke = [
-            os.path.join(os.environ["CONDA_PREFIX"], "include"),
-        ]
-    if use_setuptools:
-        extra_compile_args += ["-DMULTITHREADED_BLAS"]
-    else:
-        define_macros += [("MULTITHREADED_BLAS", None)]
+# Different extensions
+extensions = []
 
-cc = None
-lib_omp = None
-if "CC" in os.environ:
-    if "clang" in os.environ["CC"]:
-        cc = "clang"
-        if not use_mkl:
-            lib_omp = "-lomp"
-        # lib_omp = '-liomp5'
-    if "gcc" in os.environ["CC"] or "gnu-cc" in os.environ["CC"]:
-        cc = "gcc"
-if cc == "gcc" or cc is None:
-    lib_omp = "-lgomp"
-
-    if "CC" in os.environ and "gcc-" in os.environ["CC"]:
-        # For macOS & homebrew gcc:
-        # Using conda's gcc is more recommended though. Suppose using
-        # homebrew gcc whereas conda is used as general environment.
-        # This is to avoid linking conda libgomp that is incompatible
-        # with homebrew gcc.
-        try:
-            v = int(os.environ["CC"].split("-")[1])
-        except ValueError:
-            pass
-        else:
-            ary = [
-                os.sep,
-                "usr",
-                "local",
-                "opt",
-                "gcc@%d" % v,
-                "lib",
-                "gcc",
-                "%d" % v,
-                "libgomp.a",
-            ]
-            libgomp_a = os.path.join(*ary)
-            if os.path.isfile(libgomp_a):
-                lib_omp = libgomp_a
-
-if lib_omp:
-    extra_link_args.append(lib_omp)
-
-# Uncomment below to measure reciprocal_to_normal_squared_openmp performance
-# define_macros += [('MEASURE_R2N', None)]
-
-extra_link_args += extra_link_args_lapacke
-include_dirs += include_dirs_lapacke
-
-print("extra_link_args", extra_link_args)
+# Define the modules
 sources_phono3py = [
     "c/_phono3py.c",
     "c/bzgrid.c",
@@ -278,14 +109,11 @@ sources_phono3py = [
     "c/triplet_grid.c",
     "c/triplet_iw.c",
 ]
-extension_phono3py = Extension(
+extensions.append(setuptools.Extension(
     "phono3py._phono3py",
-    include_dirs=include_dirs,
-    extra_compile_args=extra_compile_args,
-    extra_link_args=extra_link_args,
-    define_macros=define_macros,
     sources=sources_phono3py,
-)
+    **opts))
+
 
 sources_phononmod = [
     "c/_phononmod.c",
@@ -294,22 +122,16 @@ sources_phononmod = [
     "c/phonon.c",
     "c/phononmod.c",
 ]
-extension_phononmod = Extension(
+extensions.append(setuptools.Extension(
     "phono3py._phononmod",
-    include_dirs=include_dirs,
-    extra_compile_args=extra_compile_args,
-    extra_link_args=extra_link_args,
     sources=sources_phononmod,
-)
+    **opts))
 
 sources_lapackepy = ["c/_lapackepy.c", "c/lapack_wrapper.c"]
-extension_lapackepy = Extension(
+extensions.append(setuptools.Extension(
     "phono3py._lapackepy",
-    extra_compile_args=extra_compile_args,
-    extra_link_args=extra_link_args,
-    include_dirs=include_dirs,
     sources=sources_lapackepy,
-)
+    **opts))
 
 packages_phono3py = [
     "phono3py",
@@ -327,10 +149,6 @@ scripts_phono3py = [
     "scripts/phono3py-kdeplot",
     "scripts/phono3py-coleigplot",
 ]
-
-########################
-# _lapackepy extension #
-########################
 
 if __name__ == "__main__":
     version_nums = [None, None, None]
@@ -364,48 +182,25 @@ if __name__ == "__main__":
     if len(version_nums) > 3:
         version += "-%d" % version_nums[3]
 
-    if use_setuptools:
-        setup(
-            name="phono3py",
-            version=version,
-            description="This is the phono3py module.",
-            author="Atsushi Togo",
-            author_email="atz.togo@gmail.com",
-            url="http://phonopy.github.io/phono3py/",
-            packages=packages_phono3py,
-            python_requires=">=3.6",
-            install_requires=[
-                "numpy>=1.11.0",
-                "scipy",
-                "PyYAML",
-                "matplotlib>=2.0.0",
-                "h5py",
-                "spglib",
-                "phonopy>=2.12,<2.13",
-            ],
-            provides=["phono3py"],
-            scripts=scripts_phono3py,
-            ext_modules=[extension_phono3py, extension_lapackepy, extension_phononmod],
-        )
-    else:
-        setup(
-            name="phono3py",
-            version=version,
-            description="This is the phono3py module.",
-            author="Atsushi Togo",
-            author_email="atz.togo@gmail.com",
-            url="http://phonopy.github.io/phono3py/",
-            packages=packages_phono3py,
-            requires=[
-                "numpy",
-                "scipy",
-                "PyYAML",
-                "matplotlib",
-                "h5py",
-                "phonopy",
-                "spglib",
-            ],
-            provides=["phono3py"],
-            scripts=scripts_phono3py,
-            ext_modules=[extension_phono3py, extension_lapackepy, extension_phononmod],
-        )
+    setuptools.setup(
+        name="phono3py",
+        version=version,
+        description="This is the phono3py module.",
+        author="Atsushi Togo",
+        author_email="atz.togo@gmail.com",
+        url="http://phonopy.github.io/phono3py/",
+        packages=packages_phono3py,
+        python_requires=">=3.6",
+        install_requires=[
+            "numpy>=1.11.0",
+            "scipy",
+            "PyYAML",
+            "matplotlib>=2.0.0",
+            "h5py",
+            "spglib",
+            "phonopy>=2.12,<2.13",
+        ],
+        provides=["phono3py"],
+        scripts=scripts_phono3py,
+        ext_modules=extensions
+    )


### PR DESCRIPTION
Instead of manually adding compilers and flags it is
now left to the user to create the appropriate site.cfg
for configuration purposes.

This is much cleaner and provides users to fully customize the build.

This also enables pip installs, for instance I can build:

   pip3 install . -vvv

Which works.
In order for pip to fully function with the numpy versions it
is important that pip uses the oldest possible numpy version
that may be pip installed. This is what oldest-supported-numpy
is for.

The PHPYOPENMP flag is not needed. The OPENMP specification states
that any C-compiler which implements preprocessor statements should
include _OPENMP when compiling with OPENMP. Therefore we simply check
for this now. I don't know of any compilers that do not define this
flag while compiling for openmp.

When retrieving MKL from numpy there is an additional macro defined:
  SCIPY_MKL_H
so now the code checks for either this macro, or the old one (MKL_LAPACKE).

I have removed support for distutils. It is far deprecated and no installations
should use this one. So better to not rely on it.
In fact it was never used since pyproject.toml had setuptools as a requirement for
building the package. So it couldn't be used in these environments in
any case.

If this is to be adopted, then the installation documentation should be updated.