### PR TITLE
Set g_zero from file

### DIFF
--- a/phono3py/conductivity/direct_solution.py
+++ b/phono3py/conductivity/direct_solution.py
@@ -475,11 +475,15 @@ class ConductivityLBTEBase(ConductivityBase):
                     print("=" * 26 + " Warning " + "=" * 26)
                     print("Inconsistency found in g_zero.")
                     print(
-                        "This inconsistency may come from slight numerical "
-                        "calculator difference between hardware or software library. "
+                        "The inconsistency may come from slight numerical "
+                        "calculator difference between hardwares or linear algebra "
+                        "libraries. "
+                        "To avoid the inconsistency, it is recommended to use the same "
+                        "phonon-*.hdf5 for generating pp-*.hdf5 because phonon "
+                        "frequencies are used to determine g_zero. "
                         "If significant difference of values below is found, it can be "
-                        "a sign of that something is broken. Otherwise, this warning "
-                        "may be ignored."
+                        "a sign of that something is really wrong. Otherwise, this "
+                        "warning may be ignored."
                     )
                     print(_g_zero.shape, g_zero.shape)
                     for i, (_v, v) in enumerate(zip(_g_zero, g_zero)):

--- a/phono3py/conductivity/rta.py
+++ b/phono3py/conductivity/rta.py
@@ -222,7 +222,7 @@ class ConductivityRTABase(ConductivityBase):
     def _set_gamma_at_sigmas(self, i):
         for j, sigma in enumerate(self._sigmas):
             self._collision.set_sigma(sigma, sigma_cutoff=self._sigma_cutoff)
-            self._collision.set_integration_weights()
+            self._collision.run_integration_weights()
 
             if self._log_level:
                 text = "Collisions will be calculated with "

--- a/phono3py/phonon3/imag_self_energy.py
+++ b/phono3py/phonon3/imag_self_energy.py
@@ -312,6 +312,9 @@ class ImagSelfEnergy:
 
     def set_interaction_strength(self, pp_strength, g_zero=None):
         """Set ph-ph interaction strengths."""
+        self._pp_strength = pp_strength
+        if g_zero is not None:
+            self._g_zero = g_zero
         self._pp.set_interaction_strength(pp_strength, g_zero=g_zero)
 
     def delete_integration_weights(self):

--- a/phono3py/phonon3/imag_self_energy.py
+++ b/phono3py/phonon3/imag_self_energy.py
@@ -136,7 +136,7 @@ class ImagSelfEnergy:
             self._pp.run(lang=self._lang, g_zero=self._g_zero)
         self._pp_strength = self._pp.interaction_strength
 
-    def set_integration_weights(self, scattering_event_class=None):
+    def run_integration_weights(self, scattering_event_class=None):
         """Compute integration weights at grid points."""
         if self._frequency_points is None:
             bi = self._pp.band_indices
@@ -310,24 +310,9 @@ class ImagSelfEnergy:
         for i, v_ave in enumerate(ave_pp):
             self._pp_strength[:, i, :, :] = v_ave / num_grid
 
-    @property
-    def interaction_strength(self):
-        """Getter and setter of ph-ph interaction strength."""
-        return self._pp_strength
-
-    @interaction_strength.setter
-    def interaction_strength(self, pp_strength):
-        self._pp_strength = pp_strength
-        self._pp.set_interaction_strength(pp_strength, g_zero=self._g_zero)
-
-    def set_interaction_strength(self, pp_strength):
+    def set_interaction_strength(self, pp_strength, g_zero=None):
         """Set ph-ph interaction strengths."""
-        warnings.warn(
-            "Use attribute, ImagSelfEnergy.interaction_strength "
-            "instead of ImagSelfEnergy.set_interaction_strength().",
-            DeprecationWarning,
-        )
-        self.interaction_strength = pp_strength
+        self._pp.set_interaction_strength(pp_strength, g_zero=g_zero)
 
     def delete_integration_weights(self):
         """Delete large ndarray's."""
@@ -894,7 +879,7 @@ def _get_imag_self_energy_at_sigma(
         detailed_gamma_at_gp_at_j = detailed_gamma_at_gp[j]
 
     if _frequency_points is None:
-        ise.set_integration_weights(scattering_event_class=scattering_event_class)
+        ise.run_integration_weights(scattering_event_class=scattering_event_class)
         for k, t in enumerate(temperatures):
             ise.temperature = t
             ise.run()
@@ -1031,7 +1016,7 @@ def run_ise_at_frequency_points_batch(
     i,
     j,
     _frequency_points,
-    ise,
+    ise: ImagSelfEnergy,
     temperatures,
     gamma,
     write_gamma_detail=False,
@@ -1065,7 +1050,7 @@ def run_ise_at_frequency_points_batch(
             sys.stdout.flush()
 
         ise.frequency_points = _frequency_points[fpts_batch]
-        ise.set_integration_weights(scattering_event_class=scattering_event_class)
+        ise.run_integration_weights(scattering_event_class=scattering_event_class)
         for ll, t in enumerate(temperatures):
             ise.temperature = t
             ise.run()


### PR DESCRIPTION
When saving ph-ph interaction strengths in `pp-*.hdf5` file, since there are many elements that contribute nothing to the collision matrix or inverse life time, only non-zero contributing elements are stored in concatenated manner when `--full-pp` is unspecified. `g_zero` contains the information of array locations of zero/non-zero interaction strength elements.

Judging either zero or non-zero contribution is achieved by checking phonon frequencies at apex of tetrahedra in tetrahedron method, and similarly in the smearing method with `--sigma-cutoff`. The calculated phonon frequencies can be slightly different in different hardwares and also in linear algebra solvers, or maybe OS. This affects to the judgement of zero or non-zero. In phono3py, `g_zero` is recalculated and is ensured if the stored and recalculated `g_zero` are equivalent. If they are different, previously phono3py was just terminated.

This PR made it unterminated but shows warning when inconsistency is found. When they are inconsistent, `g_zero` is overwritten by that in the saved `pp-*.hdf5` file.