### PR TITLE
Add option pinv_method

### DIFF
--- a/phono3py/api_phono3py.py
+++ b/phono3py/api_phono3py.py
@@ -2103,6 +2103,7 @@ class Phono3py:
         gv_delta_q=None,  # for group velocity
         is_full_pp=False,
         pinv_cutoff=1.0e-8,  # for pseudo-inversion of collision matrix
+        pinv_method=0,  # for pseudo-inversion of collision matrix
         pinv_solver=0,  # solver of pseudo-inversion of collision matrix
         write_gamma=False,
         read_gamma=False,
@@ -2175,7 +2176,11 @@ class Phono3py:
         pinv_cutoff : float, optional, default is 1.0e-8
             Direct solution only (`is_LBTE=True`). This is used as a criterion
             to judge the eigenvalues are considered as zero or not in
-            pseudo-inversion of collision matrix.
+            pseudo-inversion of collision matrix. See also `pinv_method`.
+        pinv_method : int, optional, default is 0.
+            Direct solution only (`is_LBTE=True`).
+                0. abs(eigenvalue) < `pinv_cutoff`
+                1. eigenvalue < `pinv_cutoff`
         pinv_solver : int, optional, default is 0
             Direct solution only (`is_LBTE=True`). Choice of solver of
             pseudo-inversion of collision matrix. 0 means the default choice.
@@ -2278,6 +2283,7 @@ class Phono3py:
                 conductivity_type=conductivity_type,
                 pinv_cutoff=pinv_cutoff,
                 pinv_solver=pinv_solver,
+                pinv_method=pinv_method,
                 write_collision=write_collision,
                 read_collision=read_collision,
                 write_kappa=write_kappa,

--- a/phono3py/cui/phono3py_argparse.py
+++ b/phono3py/cui/phono3py_argparse.py
@@ -583,6 +583,13 @@ def get_parser(fc_symmetry=False, is_nac=False, load_phono3py_yaml=False):
         help="Switch of LBTE pinv solver",
     )
     parser.add_argument(
+        "--pinv-method",
+        dest="pinv_method",
+        type=int,
+        default=None,
+        help="Switch of LBTE pinv method",
+    )
+    parser.add_argument(
         "--pm",
         dest="is_plusminus_displacements",
         action="store_true",

--- a/phono3py/cui/phono3py_script.py
+++ b/phono3py/cui/phono3py_script.py
@@ -35,7 +35,7 @@
 
 import copy
 import sys
-from typing import Optional, Union
+from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 from phonopy.cui.collect_cell_info import collect_cell_info
@@ -683,7 +683,9 @@ def check_supercell_in_yaml(cell_info, ph3, distance_to_A, log_level):
                 sys.exit(1)
 
 
-def init_phono3py(settings, cell_info, interface_mode, symprec, log_level):
+def init_phono3py(
+    settings, cell_info, interface_mode, symprec, log_level
+) -> Tuple[Phono3py, Dict]:
     """Initialize phono3py and update settings by default values."""
     physical_units = get_default_physical_units(interface_mode)
     distance_to_A = physical_units["distance_to_A"]
@@ -1391,6 +1393,7 @@ def main(**argparse_control):
             is_full_pp=settings.is_full_pp,
             pinv_cutoff=settings.pinv_cutoff,
             pinv_solver=settings.pinv_solver,
+            pinv_method=settings.pinv_method,
             write_gamma=settings.write_gamma,
             read_gamma=settings.read_gamma,
             write_kappa=True,

--- a/phono3py/cui/settings.py
+++ b/phono3py/cui/settings.py
@@ -85,6 +85,7 @@ class Phono3pySettings(Settings):
         "phonon_supercell_matrix": None,
         "pinv_cutoff": 1.0e-8,
         "pinv_solver": 0,
+        "pinv_method": 0,
         "pp_conversion_factor": None,
         "scattering_event_class": None,  # scattering event class 1 or 2
         "sigma_cutoff_width": None,
@@ -255,6 +256,10 @@ class Phono3pySettings(Settings):
     def set_pinv_cutoff(self, val):
         """Set pinv_cutoff."""
         self._v["pinv_cutoff"] = val
+
+    def set_pinv_method(self, val):
+        """Set pinv_method."""
+        self._v["pinv_method"] = val
 
     def set_pinv_solver(self, val):
         """Set pinv_solver."""
@@ -520,6 +525,10 @@ class Phono3pyConfParser(ConfParser):
             if self._args.pinv_cutoff is not None:
                 self._confs["pinv_cutoff"] = self._args.pinv_cutoff
 
+        if "pinv_method" in self._args:
+            if self._args.pinv_method is not None:
+                self._confs["pinv_method"] = self._args.pinv_method
+
         if "pinv_solver" in self._args:
             if self._args.pinv_solver is not None:
                 self._confs["pinv_solver"] = self._args.pinv_solver
@@ -663,6 +672,7 @@ class Phono3pyConfParser(ConfParser):
 
             # int
             if conf_key in (
+                "pinv_method",
                 "pinv_solver",
                 "num_points_in_batch",
                 "scattering_event_class",
@@ -888,6 +898,10 @@ class Phono3pyConfParser(ConfParser):
         # Cutoff frequency for pseudo inversion of collision matrix
         if "pinv_cutoff" in params:
             self._settings.set_pinv_cutoff(params["pinv_cutoff"])
+
+        # Switch for pseudo-inverse method either taking abs or not.
+        if "pinv_method" in params:
+            self._settings.set_pinv_method(params["pinv_method"])
 
         # Switch for pseudo-inverse solver
         if "pinv_solver" in params:


### PR DESCRIPTION
This is an integer 0 or 1. With 0 (current default), in the pinv of collision
matrix of direct solution, abs(eig) < pinv_cutoff is evaluated, but with 1,
eig < pinv_cutoff is evaluated. With this commit, the default behaviour is
unchanged.