### PR TITLE
Peformance tuning

### DIFF
--- a/c/_phono3py.c
+++ b/c/_phono3py.c
@@ -367,6 +367,7 @@ static PyObject *py_get_pp_collision(PyObject *self, PyObject *args) {
     long is_NU;
     long symmetrize_fc3_q;
     long bz_grid_type;
+    long openmp_per_triplets;
 
     double *gamma;
     long(*relative_grid_address)[4][3];
@@ -392,12 +393,13 @@ static PyObject *py_get_pp_collision(PyObject *self, PyObject *args) {
     long is_compact_fc3;
 
     if (!PyArg_ParseTuple(
-            args, "OOOOOOOOlOOOOOOOOOOlld", &py_gamma,
+            args, "OOOOOOOOlOOOOOOOOOOlldl", &py_gamma,
             &py_relative_grid_address, &py_frequencies, &py_eigenvectors,
             &py_triplets, &py_triplet_weights, &py_bz_grid_addresses,
             &py_bz_map, &bz_grid_type, &py_D_diag, &py_Q, &py_fc3, &py_svecs,
             &py_multi, &py_masses, &py_p2s_map, &py_s2p_map, &py_band_indices,
-            &py_temperatures, &is_NU, &symmetrize_fc3_q, &cutoff_frequency)) {
+            &py_temperatures, &is_NU, &symmetrize_fc3_q, &cutoff_frequency,
+            &openmp_per_triplets)) {
         return NULL;
     }
 
@@ -435,7 +437,7 @@ static PyObject *py_get_pp_collision(PyObject *self, PyObject *args) {
         num_triplets, triplet_weights, bz_grid_addresses, bz_map, bz_grid_type,
         D_diag, Q, fc3, is_compact_fc3, svecs, multi_dims, multi, masses, p2s,
         s2p, band_indices, temperatures, is_NU, symmetrize_fc3_q,
-        cutoff_frequency);
+        cutoff_frequency, openmp_per_triplets);
 
     free(band_indices);
     band_indices = NULL;
@@ -468,6 +470,7 @@ static PyObject *py_get_pp_collision_with_sigma(PyObject *self,
     double sigma;
     double sigma_cutoff;
     double cutoff_frequency;
+    long openmp_per_triplets;
 
     double *gamma;
     double *frequencies;
@@ -490,13 +493,13 @@ static PyObject *py_get_pp_collision_with_sigma(PyObject *self,
     long i;
     long is_compact_fc3;
 
-    if (!PyArg_ParseTuple(args, "OddOOOOOOOOOOOOOOOlld", &py_gamma, &sigma,
-                          &sigma_cutoff, &py_frequencies, &py_eigenvectors,
-                          &py_triplets, &py_triplet_weights,
-                          &py_bz_grid_addresses, &py_D_diag, &py_Q, &py_fc3,
-                          &py_svecs, &py_multi, &py_masses, &py_p2s_map,
-                          &py_s2p_map, &py_band_indices, &py_temperatures,
-                          &is_NU, &symmetrize_fc3_q, &cutoff_frequency)) {
+    if (!PyArg_ParseTuple(
+            args, "OddOOOOOOOOOOOOOOOlldl", &py_gamma, &sigma, &sigma_cutoff,
+            &py_frequencies, &py_eigenvectors, &py_triplets,
+            &py_triplet_weights, &py_bz_grid_addresses, &py_D_diag, &py_Q,
+            &py_fc3, &py_svecs, &py_multi, &py_masses, &py_p2s_map, &py_s2p_map,
+            &py_band_indices, &py_temperatures, &is_NU, &symmetrize_fc3_q,
+            &cutoff_frequency, &openmp_per_triplets)) {
         return NULL;
     }
 
@@ -530,7 +533,8 @@ static PyObject *py_get_pp_collision_with_sigma(PyObject *self,
         gamma, sigma, sigma_cutoff, frequencies, eigenvectors, triplets,
         num_triplets, triplet_weights, bz_grid_addresses, D_diag, Q, fc3,
         is_compact_fc3, svecs, multi_dims, multi, masses, p2s, s2p,
-        band_indices, temperatures, is_NU, symmetrize_fc3_q, cutoff_frequency);
+        band_indices, temperatures, is_NU, symmetrize_fc3_q, cutoff_frequency,
+        openmp_per_triplets);
 
     free(band_indices);
     band_indices = NULL;

--- a/c/_phono3py.c
+++ b/c/_phono3py.c
@@ -273,6 +273,7 @@ static PyObject *py_get_interaction(PyObject *self, PyObject *args) {
     PyArrayObject *py_band_indices;
     double cutoff_frequency;
     long symmetrize_fc3_q;
+    long openmp_per_triplets;
 
     Darray *fc3_normal_squared;
     Darray *freqs;
@@ -294,12 +295,12 @@ static PyObject *py_get_interaction(PyObject *self, PyObject *args) {
     long i;
     long is_compact_fc3;
 
-    if (!PyArg_ParseTuple(args, "OOOOOOOOOOOOOOOld", &py_fc3_normal_squared,
-                          &py_g_zero, &py_frequencies, &py_eigenvectors,
-                          &py_triplets, &py_bz_grid_addresses, &py_D_diag,
-                          &py_Q, &py_fc3, &py_svecs, &py_multi, &py_masses,
-                          &py_p2s_map, &py_s2p_map, &py_band_indices,
-                          &symmetrize_fc3_q, &cutoff_frequency)) {
+    if (!PyArg_ParseTuple(
+            args, "OOOOOOOOOOOOOOOldl", &py_fc3_normal_squared, &py_g_zero,
+            &py_frequencies, &py_eigenvectors, &py_triplets,
+            &py_bz_grid_addresses, &py_D_diag, &py_Q, &py_fc3, &py_svecs,
+            &py_multi, &py_masses, &py_p2s_map, &py_s2p_map, &py_band_indices,
+            &symmetrize_fc3_q, &cutoff_frequency, &openmp_per_triplets)) {
         return NULL;
     }
 
@@ -333,8 +334,8 @@ static PyObject *py_get_interaction(PyObject *self, PyObject *args) {
     ph3py_get_interaction(fc3_normal_squared, g_zero, freqs, eigvecs, triplets,
                           num_triplets, bz_grid_addresses, D_diag, Q, fc3,
                           is_compact_fc3, svecs, multi_dims, multi, masses, p2s,
-                          s2p, band_indices, symmetrize_fc3_q,
-                          cutoff_frequency);
+                          s2p, band_indices, symmetrize_fc3_q, cutoff_frequency,
+                          openmp_per_triplets);
 
     free(fc3_normal_squared);
     fc3_normal_squared = NULL;

--- a/c/interaction.c
+++ b/c/interaction.c
@@ -71,18 +71,15 @@ static void real_to_normal_sym_q(
     const long openmp_at_bands);
 
 /* fc3_normal_squared[num_triplets, num_band0, num_band, num_band] */
-void itr_get_interaction(Darray *fc3_normal_squared, const char *g_zero,
-                         const Darray *frequencies,
-                         const lapack_complex_double *eigenvectors,
-                         const long (*triplets)[3], const long num_triplets,
-                         const ConstBZGrid *bzgrid, const double *fc3,
-                         const long is_compact_fc3, const double (*svecs)[3],
-                         const long multi_dims[2],
-                         const long (*multiplicity)[2], const double *masses,
-                         const long *p2s_map, const long *s2p_map,
-                         const long *band_indices, const long symmetrize_fc3_q,
-                         const double cutoff_frequency) {
-    long openmp_per_triplets;
+void itr_get_interaction(
+    Darray *fc3_normal_squared, const char *g_zero, const Darray *frequencies,
+    const lapack_complex_double *eigenvectors, const long (*triplets)[3],
+    const long num_triplets, const ConstBZGrid *bzgrid, const double *fc3,
+    const long is_compact_fc3, const double (*svecs)[3],
+    const long multi_dims[2], const long (*multiplicity)[2],
+    const double *masses, const long *p2s_map, const long *s2p_map,
+    const long *band_indices, const long symmetrize_fc3_q,
+    const double cutoff_frequency, const long openmp_per_triplets) {
     long(*g_pos)[4];
     long i;
     long num_band, num_band0, num_band_prod, num_g_pos;
@@ -92,12 +89,6 @@ void itr_get_interaction(Darray *fc3_normal_squared, const char *g_zero,
     num_band0 = fc3_normal_squared->dims[1];
     num_band = frequencies->dims[1];
     num_band_prod = num_band0 * num_band * num_band;
-
-    if (num_triplets > num_band) {
-        openmp_per_triplets = 1;
-    } else {
-        openmp_per_triplets = 0;
-    }
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(guided) private( \

--- a/c/interaction.h
+++ b/c/interaction.h
@@ -39,17 +39,15 @@
 #include "lapack_wrapper.h"
 #include "phonoc_array.h"
 
-void itr_get_interaction(Darray *fc3_normal_squared, const char *g_zero,
-                         const Darray *frequencies,
-                         const lapack_complex_double *eigenvectors,
-                         const long (*triplets)[3], const long num_triplets,
-                         const ConstBZGrid *bzgrid, const double *fc3,
-                         const long is_compact_fc3, const double (*svecs)[3],
-                         const long multi_dims[2],
-                         const long (*multiplicity)[2], const double *masses,
-                         const long *p2s_map, const long *s2p_map,
-                         const long *band_indices, const long symmetrize_fc3_q,
-                         const double cutoff_frequency);
+void itr_get_interaction(
+    Darray *fc3_normal_squared, const char *g_zero, const Darray *frequencies,
+    const lapack_complex_double *eigenvectors, const long (*triplets)[3],
+    const long num_triplets, const ConstBZGrid *bzgrid, const double *fc3,
+    const long is_compact_fc3, const double (*svecs)[3],
+    const long multi_dims[2], const long (*multiplicity)[2],
+    const double *masses, const long *p2s_map, const long *s2p_map,
+    const long *band_indices, const long symmetrize_fc3_q,
+    const double cutoff_frequency, const long openmp_per_triplets);
 void itr_get_interaction_at_triplet(
     double *fc3_normal_squared, const long num_band0, const long num_band,
     const long (*g_pos)[4], const long num_g_pos, const double *frequencies,

--- a/c/phono3py.c
+++ b/c/phono3py.c
@@ -62,7 +62,7 @@ long ph3py_get_interaction(
     const long multi_dims[2], const long (*multiplicity)[2],
     const double *masses, const long *p2s_map, const long *s2p_map,
     const long *band_indices, const long symmetrize_fc3_q,
-    const double cutoff_frequency) {
+    const double cutoff_frequency, const long openmp_per_triplets) {
     ConstBZGrid *bzgrid;
     long i, j;
 
@@ -84,7 +84,8 @@ long ph3py_get_interaction(
                         (lapack_complex_double *)eigenvectors, triplets,
                         num_triplets, bzgrid, fc3, is_compact_fc3, svecs,
                         multi_dims, multiplicity, masses, p2s_map, s2p_map,
-                        band_indices, symmetrize_fc3_q, cutoff_frequency);
+                        band_indices, symmetrize_fc3_q, cutoff_frequency,
+                        openmp_per_triplets);
     free(bzgrid);
     bzgrid = NULL;
 

--- a/c/phono3py.c
+++ b/c/phono3py.c
@@ -103,7 +103,8 @@ long ph3py_get_pp_collision(
     const long multi_dims[2], const long (*multiplicity)[2],
     const double *masses, const long *p2s_map, const long *s2p_map,
     const Larray *band_indices, const Darray *temperatures, const long is_NU,
-    const long symmetrize_fc3_q, const double cutoff_frequency) {
+    const long symmetrize_fc3_q, const double cutoff_frequency,
+    const long openmp_per_triplets) {
     ConstBZGrid *bzgrid;
     long i, j;
 
@@ -123,12 +124,12 @@ long ph3py_get_pp_collision(
         }
     }
 
-    ppc_get_pp_collision(imag_self_energy, relative_grid_address, frequencies,
-                         (lapack_complex_double *)eigenvectors, triplets,
-                         num_triplets, triplet_weights, bzgrid, fc3,
-                         is_compact_fc3, svecs, multi_dims, multiplicity,
-                         masses, p2s_map, s2p_map, band_indices, temperatures,
-                         is_NU, symmetrize_fc3_q, cutoff_frequency);
+    ppc_get_pp_collision(
+        imag_self_energy, relative_grid_address, frequencies,
+        (lapack_complex_double *)eigenvectors, triplets, num_triplets,
+        triplet_weights, bzgrid, fc3, is_compact_fc3, svecs, multi_dims,
+        multiplicity, masses, p2s_map, s2p_map, band_indices, temperatures,
+        is_NU, symmetrize_fc3_q, cutoff_frequency, openmp_per_triplets);
 
     free(bzgrid);
     bzgrid = NULL;
@@ -146,7 +147,8 @@ long ph3py_get_pp_collision_with_sigma(
     const long multi_dims[2], const long (*multiplicity)[2],
     const double *masses, const long *p2s_map, const long *s2p_map,
     const Larray *band_indices, const Darray *temperatures, const long is_NU,
-    const long symmetrize_fc3_q, const double cutoff_frequency) {
+    const long symmetrize_fc3_q, const double cutoff_frequency,
+    const long openmp_per_triplets) {
     ConstBZGrid *bzgrid;
     long i, j;
 
@@ -169,7 +171,7 @@ long ph3py_get_pp_collision_with_sigma(
         (lapack_complex_double *)eigenvectors, triplets, num_triplets,
         triplet_weights, bzgrid, fc3, is_compact_fc3, svecs, multi_dims,
         multiplicity, masses, p2s_map, s2p_map, band_indices, temperatures,
-        is_NU, symmetrize_fc3_q, cutoff_frequency);
+        is_NU, symmetrize_fc3_q, cutoff_frequency, openmp_per_triplets);
 
     free(bzgrid);
     bzgrid = NULL;

--- a/c/phono3py.h
+++ b/c/phono3py.h
@@ -50,7 +50,8 @@ long ph3py_get_interaction(
     const long is_compact_fc3, const double (*svecs)[3],
     const long multi_dims[2], const long (*multi)[2], const double *masses,
     const long *p2s_map, const long *s2p_map, const long *band_indices,
-    const long symmetrize_fc3_q, const double cutoff_frequency);
+    const long symmetrize_fc3_q, const double cutoff_frequency,
+    const long openmp_per_triplets);
 long ph3py_get_pp_collision(
     double *imag_self_energy,
     const long relative_grid_address[24][4][3], /* thm */

--- a/c/phono3py.h
+++ b/c/phono3py.h
@@ -63,7 +63,7 @@ long ph3py_get_pp_collision(
     const long multi_dims[2], const long (*multi)[2], const double *masses,
     const long *p2s_map, const long *s2p_map, const Larray *band_indices,
     const Darray *temperatures, const long is_NU, const long symmetrize_fc3_q,
-    const double cutoff_frequency);
+    const double cutoff_frequency, const long openmp_per_triplets);
 long ph3py_get_pp_collision_with_sigma(
     double *imag_self_energy, const double sigma, const double sigma_cutoff,
     const double *frequencies, const _lapack_complex_double *eigenvectors,
@@ -74,7 +74,7 @@ long ph3py_get_pp_collision_with_sigma(
     const long multi_dims[2], const long (*multi)[2], const double *masses,
     const long *p2s_map, const long *s2p_map, const Larray *band_indices,
     const Darray *temperatures, const long is_NU, const long symmetrize_fc3_q,
-    const double cutoff_frequency);
+    const double cutoff_frequency, const long openmp_per_triplets);
 void ph3py_get_imag_self_energy_at_bands_with_g(
     double *imag_self_energy, const Darray *fc3_normal_squared,
     const double *frequencies, const long (*triplets)[3],

--- a/c/pp_collision.c
+++ b/c/pp_collision.c
@@ -72,10 +72,10 @@ void ppc_get_pp_collision(
     const long multi_dims[2], const long (*multiplicity)[2],
     const double *masses, const long *p2s_map, const long *s2p_map,
     const Larray *band_indices, const Darray *temperatures, const long is_NU,
-    const long symmetrize_fc3_q, const double cutoff_frequency) {
+    const long symmetrize_fc3_q, const double cutoff_frequency,
+    const long openmp_per_triplets) {
     long i;
     long num_band, num_band0, num_band_prod, num_temps;
-    long openmp_per_triplets;
     double *ise, *freqs_at_gp, *g;
     char *g_zero;
     long tp_relative_grid_address[2][24][4][3];
@@ -95,12 +95,6 @@ void ppc_get_pp_collision(
     for (i = 0; i < num_band0; i++) {
         freqs_at_gp[i] =
             frequencies[triplets[0][0] * num_band + band_indices->data[i]];
-    }
-
-    if (num_triplets > num_band) {
-        openmp_per_triplets = 1;
-    } else {
-        openmp_per_triplets = 0;
     }
 
     tpl_set_relative_grid_address(tp_relative_grid_address,
@@ -151,10 +145,11 @@ void ppc_get_pp_collision_with_sigma(
     const long multi_dims[2], const long (*multiplicity)[2],
     const double *masses, const long *p2s_map, const long *s2p_map,
     const Larray *band_indices, const Darray *temperatures, const long is_NU,
-    const long symmetrize_fc3_q, const double cutoff_frequency) {
+    const long symmetrize_fc3_q, const double cutoff_frequency,
+    const long openmp_per_triplets) {
     long i;
     long num_band, num_band0, num_band_prod, num_temps;
-    long openmp_per_triplets, const_adrs_shift;
+    long const_adrs_shift;
     double cutoff;
     double *ise, *freqs_at_gp, *g;
     char *g_zero;
@@ -176,12 +171,6 @@ void ppc_get_pp_collision_with_sigma(
     for (i = 0; i < num_band0; i++) {
         freqs_at_gp[i] =
             frequencies[triplets[0][0] * num_band + band_indices->data[i]];
-    }
-
-    if (num_triplets > num_band) {
-        openmp_per_triplets = 1;
-    } else {
-        openmp_per_triplets = 0;
     }
 
     cutoff = sigma * sigma_cutoff;

--- a/c/pp_collision.h
+++ b/c/pp_collision.h
@@ -49,7 +49,8 @@ void ppc_get_pp_collision(
     const long multi_dims[2], const long (*multiplicity)[2],
     const double *masses, const long *p2s_map, const long *s2p_map,
     const Larray *band_indices, const Darray *temperatures, const long is_NU,
-    const long symmetrize_fc3_q, const double cutoff_frequency);
+    const long symmetrize_fc3_q, const double cutoff_frequency,
+    const long openmp_per_triplets);
 void ppc_get_pp_collision_with_sigma(
     double *imag_self_energy, const double sigma, const double sigma_cutoff,
     const double *frequencies, const lapack_complex_double *eigenvectors,
@@ -59,6 +60,7 @@ void ppc_get_pp_collision_with_sigma(
     const long multi_dims[2], const long (*multiplicity)[2],
     const double *masses, const long *p2s_map, const long *s2p_map,
     const Larray *band_indices, const Darray *temperatures, const long is_NU,
-    const long symmetrize_fc3_q, const double cutoff_frequency);
+    const long symmetrize_fc3_q, const double cutoff_frequency,
+    const long openmp_per_triplets);
 
 #endif

--- a/phono3py/api_phono3py.py
+++ b/phono3py/api_phono3py.py
@@ -1312,6 +1312,7 @@ class Phono3py:
         frequency_scale_factor=None,
         symmetrize_fc3q=False,
         lapack_zheev_uplo="L",
+        openmp_per_triplets=None,
     ):
         """Initialize ph-ph interaction calculation.
 
@@ -1347,6 +1348,11 @@ class Phono3py:
         lapack_zheev_uplo : str, optional
             'L' or 'U'. Default is 'L'. This is passed to LAPACK zheev
             used for phonon solver.
+        openmp_per_triplets : bool or None, optional, default is None
+            Normally this parameter should not be touched.
+            When `True`, ph-ph interaction strength calculation runs with
+            OpenMP distribution over triplets, and over bands when `False`.
+            `None` will choose one of them automatically.
 
         """
         if self.mesh_numbers is None:
@@ -1380,6 +1386,7 @@ class Phono3py:
             is_mesh_symmetry=self._is_mesh_symmetry,
             symmetrize_fc3q=_symmetrize_fc3q,
             lapack_zheev_uplo=_lapack_zheev_uplo,
+            openmp_per_triplets=openmp_per_triplets,
         )
         self._interaction.nac_q_direction = nac_q_direction
         self._init_dynamical_matrix()
@@ -2244,10 +2251,10 @@ class Phono3py:
         compression: str, optional, default is "gzip"
             When writing results into files in hdf5, large data are compressed
             by this options. See the detail at h5py documentation.
-        input_filename : str, optiona, default is None
+        input_filename : str, optional, default is None
             When specified, the string is inserted before filename extension
             in reading files.
-        output_filename=None
+        output_filename : str, optional, default is None
             When specified, the string is inserted before filename extension
             in writing files.
 

--- a/phono3py/conductivity/rta.py
+++ b/phono3py/conductivity/rta.py
@@ -99,7 +99,6 @@ class ConductivityRTABase(ConductivityBase):
         self._use_const_ave_pp = None
         self._averaged_pp_interaction = None
         self._num_ignored_phonon_modes = None
-        self._openmp_per_triplets = None
 
         super().__init__(
             interaction,
@@ -352,13 +351,13 @@ class ConductivityRTABase(ConductivityBase):
 
             # True: OpenMP over triplets
             # False: OpenMP over bands
-            if self._openmp_per_triplets is None:
+            if self._pp.openmp_per_triplets is None:
                 if len(triplets_at_q) > num_band:
                     openmp_per_triplets = True
                 else:
                     openmp_per_triplets = False
             else:
-                openmp_per_triplets = self._openmp_per_triplets
+                openmp_per_triplets = self._pp.openmp_per_triplets
 
             if sigma is None:
                 phono3c.pp_collision(

--- a/test/conductivity/test_kappa_RTA.py
+++ b/test/conductivity/test_kappa_RTA.py
@@ -1,5 +1,6 @@
 """Test for Conductivity_RTA.py."""
 import numpy as np
+import pytest
 
 from phono3py import Phono3py
 
@@ -27,35 +28,49 @@ aln_lda_kappa_RTA = [203.304059, 203.304059, 213.003125, 0, 0, 0]
 aln_lda_kappa_RTA_with_sigmas = [213.820000, 213.820000, 224.800121, 0, 0, 0]
 
 
-def test_kappa_RTA_si(si_pbesol):
+@pytest.mark.parametrize("openmp_per_triplets", [True, False])
+def test_kappa_RTA_si(
+    si_pbesol: Phono3py,
+    openmp_per_triplets: bool,
+):
     """Test RTA by Si."""
-    kappa = _get_kappa(si_pbesol, [9, 9, 9]).ravel()
+    kappa = _get_kappa(
+        si_pbesol,
+        [9, 9, 9],
+        openmp_per_triplets=openmp_per_triplets,
+    ).ravel()
     np.testing.assert_allclose(si_pbesol_kappa_RTA, kappa, atol=0.5)
 
 
-def test_kappa_RTA_si_full_pp(si_pbesol):
+@pytest.mark.parametrize("openmp_per_triplets", [True, False])
+def test_kappa_RTA_si_full_pp(si_pbesol: Phono3py, openmp_per_triplets: bool):
     """Test RTA with full-pp by Si."""
-    kappa = _get_kappa(si_pbesol, [9, 9, 9], is_full_pp=True).ravel()
+    kappa = _get_kappa(
+        si_pbesol, [9, 9, 9], is_full_pp=True, openmp_per_triplets=openmp_per_triplets
+    ).ravel()
     np.testing.assert_allclose(si_pbesol_kappa_RTA, kappa, atol=0.5)
 
 
-def test_kappa_RTA_si_iso(si_pbesol):
+def test_kappa_RTA_si_iso(si_pbesol: Phono3py):
     """Test RTA with isotope scattering by Si."""
     kappa = _get_kappa(si_pbesol, [9, 9, 9], is_isotope=True).ravel()
     np.testing.assert_allclose(si_pbesol_kappa_RTA_iso, kappa, atol=0.5)
 
 
-def test_kappa_RTA_si_with_sigma(si_pbesol):
+@pytest.mark.parametrize("openmp_per_triplets", [True, False])
+def test_kappa_RTA_si_with_sigma(si_pbesol: Phono3py, openmp_per_triplets: bool):
     """Test RTA with smearing method by Si."""
     si_pbesol.sigmas = [
         0.1,
     ]
-    kappa = _get_kappa(si_pbesol, [9, 9, 9]).ravel()
+    kappa = _get_kappa(
+        si_pbesol, [9, 9, 9], openmp_per_triplets=openmp_per_triplets
+    ).ravel()
     np.testing.assert_allclose(si_pbesol_kappa_RTA_with_sigmas, kappa, atol=0.5)
     si_pbesol.sigmas = None
 
 
-def test_kappa_RTA_si_with_sigma_full_pp(si_pbesol):
+def test_kappa_RTA_si_with_sigma_full_pp(si_pbesol: Phono3py):
     """Test RTA with smearing method and full-pp by Si."""
     si_pbesol.sigmas = [
         0.1,
@@ -66,7 +81,7 @@ def test_kappa_RTA_si_with_sigma_full_pp(si_pbesol):
     si_pbesol.sigmas = None
 
 
-def test_kappa_RTA_si_with_sigma_iso(si_pbesol):
+def test_kappa_RTA_si_with_sigma_iso(si_pbesol: Phono3py):
     """Test RTA with smearing method and isotope scattering by Si."""
     si_pbesol.sigmas = [
         0.1,
@@ -76,13 +91,13 @@ def test_kappa_RTA_si_with_sigma_iso(si_pbesol):
     si_pbesol.sigmas = None
 
 
-def test_kappa_RTA_si_compact_fc(si_pbesol_compact_fc):
+def test_kappa_RTA_si_compact_fc(si_pbesol_compact_fc: Phono3py):
     """Test RTA with compact-fc by Si."""
     kappa = _get_kappa(si_pbesol_compact_fc, [9, 9, 9]).ravel()
     np.testing.assert_allclose(si_pbesol_kappa_RTA, kappa, atol=0.5)
 
 
-def test_kappa_RTA_si_nosym(si_pbesol, si_pbesol_nosym):
+def test_kappa_RTA_si_nosym(si_pbesol: Phono3py, si_pbesol_nosym: Phono3py):
     """Test RTA without considering symmetry by Si."""
     si_pbesol_nosym.fc2 = si_pbesol.fc2
     si_pbesol_nosym.fc3 = si_pbesol.fc3
@@ -326,9 +341,9 @@ def test_kappa_RTA_aln_with_sigma(aln_lda):
     aln_lda.sigma_cutoff = None
 
 
-def _get_kappa(ph3, mesh, is_isotope=False, is_full_pp=False):
+def _get_kappa(ph3, mesh, is_isotope=False, is_full_pp=False, openmp_per_triplets=None):
     ph3.mesh_numbers = mesh
-    ph3.init_phph_interaction()
+    ph3.init_phph_interaction(openmp_per_triplets=openmp_per_triplets)
     ph3.run_thermal_conductivity(
         temperatures=[
             300,


### PR DESCRIPTION
- `openmp_per_triplets` was extracted from `phono3c.pp_collision` and `phono3c.pp_collision_with_sigma` to `rta.py`.
- `openmp_per_triplets` was extracted from `phono3c.interaction` to `interaction.py`.

Both of these can be controlled from `Phono3py.init_phph_interaction`.