### PR TITLE
Fix broken data structure related to phonon_supercell_matrix etc

### DIFF
--- a/phono3py/cui/load.py
+++ b/phono3py/cui/load.py
@@ -36,6 +36,7 @@
 from __future__ import annotations
 
 import os
+import pathlib
 from collections.abc import Sequence
 from typing import Optional, Union
 
@@ -390,14 +391,13 @@ def set_dataset_and_force_constants(
         cutoff_pair_distance=cutoff_pair_distance,
         log_level=log_level,
     )
-    if ph3py.phonon_supercell_matrix is not None:
-        read_fc["fc2"] = _set_dataset_phonon_dataset_or_fc2(
-            ph3py,
-            ph3py_yaml=ph3py_yaml,
-            fc2_filename=fc2_filename,
-            forces_fc2_filename=forces_fc2_filename,
-            log_level=log_level,
-        )
+    read_fc["fc2"] = _set_dataset_phonon_dataset_or_fc2(
+        ph3py,
+        ph3py_yaml=ph3py_yaml,
+        fc2_filename=fc2_filename,
+        forces_fc2_filename=forces_fc2_filename,
+        log_level=log_level,
+    )
 
     # Cases that dataset is in phono3py.yaml but not forces.
     if ph3py.dataset is None:
@@ -487,14 +487,14 @@ def _set_dataset_or_fc3(
             cutoff_pair_distance,
             log_level,
         )
-    elif os.path.isfile("fc3.hdf5"):
+    elif pathlib.Path("fc3.hdf5").exists():
         fc3 = read_fc3_from_hdf5(filename="fc3.hdf5", p2s_map=p2s_map)
         _check_fc3_shape(ph3py, fc3)
         ph3py.fc3 = fc3
         read_fc3 = True
         if log_level:
             print('fc3 was read from "fc3.hdf5".')
-    elif os.path.isfile("FORCES_FC3"):
+    elif pathlib.Path("FORCES_FC3").exists():
         _set_dataset_for_fc3(
             ph3py,
             ph3py_yaml,
@@ -544,14 +544,17 @@ def _set_dataset_phonon_dataset_or_fc2(
             "phonon_fc2",
             log_level,
         )
-    elif os.path.isfile("fc2.hdf5"):
+    elif pathlib.Path("fc2.hdf5").exists():
         fc2 = read_fc2_from_hdf5(filename="fc2.hdf5", p2s_map=phonon_p2s_map)
         _check_fc2_shape(ph3py, fc2)
         ph3py.fc2 = fc2
         read_fc2 = True
         if log_level:
             print('fc2 was read from "fc2.hdf5".')
-    elif os.path.isfile("FORCES_FC2"):
+    elif (
+        pathlib.Path("FORCES_FC2").exists()
+        and ph3py.phonon_supercell_matrix is not None
+    ):
         _set_dataset_for_fc2(
             ph3py,
             ph3py_yaml,
@@ -583,7 +586,10 @@ def _set_dataset_phonon_dataset_or_fc2(
             "fc2",
             log_level,
         )
-    elif os.path.isfile("FORCES_FC3"):
+    elif (
+        pathlib.Path("FORCES_FC3").exists()
+        and ph3py.phonon_supercell_matrix is not None
+    ):
         # suppose fc3.hdf5 is read but fc2.hdf5 doesn't exist.
         _set_dataset_for_fc2(
             ph3py,

--- a/phono3py/interface/phono3py_yaml.py
+++ b/phono3py/interface/phono3py_yaml.py
@@ -115,18 +115,18 @@ class Phono3pyYamlLoader(PhonopyYamlLoaderBase):
 
         """
         super()._parse_all_cells()
-        if "phonon_primitive_cell" in self._yaml:
-            self._data.phonon_primitive = self._parse_cell(
-                self._yaml["phonon_primitive_cell"]
-            )
-        if "phonon_supercell" in self._yaml:
-            self._data.phonon_supercell = self._parse_cell(
-                self._yaml["phonon_supercell"]
-            )
         if "phonon_supercell_matrix" in self._yaml:
             self._data.phonon_supercell_matrix = np.array(
                 self._yaml["phonon_supercell_matrix"], dtype="intc", order="C"
             )
+            if "phonon_primitive_cell" in self._yaml:
+                self._data.phonon_primitive = self._parse_cell(
+                    self._yaml["phonon_primitive_cell"]
+                )
+            if "phonon_supercell" in self._yaml:
+                self._data.phonon_supercell = self._parse_cell(
+                    self._yaml["phonon_supercell"]
+                )
 
     def _parse_dataset(self):
         """Parse phonon_dataset.
@@ -137,8 +137,6 @@ class Phono3pyYamlLoader(PhonopyYamlLoaderBase):
         self._data.phonon_dataset = self._get_dataset(
             self._data.phonon_supercell, key_prefix="phonon_"
         )
-        if self._data.phonon_dataset is None:
-            self._data.phonon_dataset = self._get_dataset(self._data.phonon_supercell)
 
     def _parse_fc3_dataset(self):
         """Parse force dataset for fc3.
@@ -286,13 +284,14 @@ class Phono3pyYamlDumper(PhonopyYamlDumperBase):
 
         """
         lines = super()._cell_info_yaml_lines()
-        lines += self._supercell_matrix_yaml_lines(
-            self._data.phonon_supercell_matrix, "phonon_supercell_matrix"
-        )
-        lines += self._primitive_yaml_lines(
-            self._data.phonon_primitive, "phonon_primitive_cell"
-        )
-        lines += self._phonon_supercell_yaml_lines()
+        if self._data.phonon_supercell_matrix is not None:
+            lines += self._supercell_matrix_yaml_lines(
+                self._data.phonon_supercell_matrix, "phonon_supercell_matrix"
+            )
+            lines += self._primitive_yaml_lines(
+                self._data.phonon_primitive, "phonon_primitive_cell"
+            )
+            lines += self._phonon_supercell_yaml_lines()
         return lines
 
     def _phonon_supercell_yaml_lines(self):


### PR DESCRIPTION
When different supercell size for fc2 is used, `ph3.phonon_supercell_matrix` is `None`. This is implicitly used as the flag to invoke this mode, i.e., different supercell sizes for fc3 and fc2.

This rule was not followed in a few places, not only in CUI logic for reading various types of inputs, but also in Yaml dumper and loader.

Probably a specific flag in boolean type should be prepared.