### PR TITLE
Preliminary support of symfc

### DIFF
--- a/.github/workflows/phono3py-pytest-conda-mkl-phphmtblas.yml
+++ b/.github/workflows/phono3py-pytest-conda-mkl-phphmtblas.yml
@@ -26,6 +26,13 @@ jobs:
         conda install --yes python=${{ matrix.python-version }}
         #conda install --yes matplotlib-base pyyaml "libblas=*=*openblas" openblas h5py scipy pytest codecov pytest-cov spglib alm cmake c-compiler
         conda install --yes matplotlib-base pyyaml "libblas=*=*mkl" mkl-include h5py scipy pytest codecov pytest-cov spglib alm cmake c-compiler
+    - name: Install symfc develop branch
+      run: |
+        conda activate test
+        git clone --depth 1 https://github.com/symfc/symfc.git
+        cd symfc
+        pip install -e . -vvv
+        cd ..
     - name: Install phonopy develop branch
       run: |
         conda activate test

--- a/.github/workflows/phono3py-pytest-conda-mkl-v2.yml
+++ b/.github/workflows/phono3py-pytest-conda-mkl-v2.yml
@@ -26,6 +26,13 @@ jobs:
         conda install --yes python=${{ matrix.python-version }}
         #conda install --yes matplotlib-base pyyaml "libblas=*=*openblas" openblas h5py scipy pytest codecov pytest-cov spglib alm cmake c-compiler
         conda install --yes matplotlib-base pyyaml "libblas=*=*mkl" mkl-include h5py scipy pytest codecov pytest-cov spglib alm cmake c-compiler
+    - name: Install symfc develop branch
+      run: |
+        conda activate test
+        git clone --depth 1 https://github.com/symfc/symfc.git
+        cd symfc
+        pip install -e . -vvv
+        cd ..
     - name: Install phonopy develop branch
       run: |
         conda activate test

--- a/.github/workflows/phono3py-pytest-conda-mkl.yml
+++ b/.github/workflows/phono3py-pytest-conda-mkl.yml
@@ -26,6 +26,13 @@ jobs:
         conda install --yes python=${{ matrix.python-version }}
         #conda install --yes matplotlib-base pyyaml "libblas=*=*openblas" openblas h5py scipy pytest codecov pytest-cov spglib alm cmake c-compiler
         conda install --yes matplotlib-base pyyaml "libblas=*=*mkl" mkl-include h5py scipy pytest codecov pytest-cov spglib alm cmake c-compiler
+    - name: Install symfc develop branch
+      run: |
+        conda activate test
+        git clone --depth 1 https://github.com/symfc/symfc.git
+        cd symfc
+        pip install -e . -vvv
+        cd ..
     - name: Install phonopy develop branch
       run: |
         conda activate test

--- a/.github/workflows/phono3py-pytest-conda-numpy2.yml
+++ b/.github/workflows/phono3py-pytest-conda-numpy2.yml
@@ -32,6 +32,13 @@ jobs:
         cd spglib
         pip install -e . -vvv
         cd ..
+    - name: Install symfc develop branch
+      run: |
+        conda activate test
+        git clone --depth 1 https://github.com/symfc/symfc.git
+        cd symfc
+        pip install -e . -vvv
+        cd ..
     - name: Install phonopy develop branch
       run: |
         conda activate test

--- a/.github/workflows/phono3py-pytest-conda-phphmtblas.yml
+++ b/.github/workflows/phono3py-pytest-conda-phphmtblas.yml
@@ -26,6 +26,13 @@ jobs:
         conda install --yes python=${{ matrix.python-version }}
         conda install --yes matplotlib-base pyyaml "libblas=*=*openblas" openblas h5py scipy pytest codecov pytest-cov spglib alm cmake c-compiler
         #conda install --yes matplotlib-base pyyaml "libblas=*=*mkl" mkl-include h5py scipy pytest codecov pytest-cov spglib alm cmake c-compiler
+    - name: Install symfc develop branch
+      run: |
+        conda activate test
+        git clone --depth 1 https://github.com/symfc/symfc.git
+        cd symfc
+        pip install -e . -vvv
+        cd ..
     - name: Install phonopy develop branch
       run: |
         conda activate test

--- a/phono3py/api_phono3py.py
+++ b/phono3py/api_phono3py.py
@@ -1329,6 +1329,7 @@ class Phono3py:
                 fc_calculator=fc3_calculator,
                 fc_calculator_options=fc3_calculator_options,
                 is_compact_fc=is_compact_fc,
+                symmetry=self._symmetry,
                 log_level=self._log_level,
             )
         else:
@@ -1425,6 +1426,8 @@ class Phono3py:
                 fc_calculator=fc2_calculator,
                 fc_calculator_options=fc2_calculator_options,
                 atom_list=p2s_map,
+                symmetry=self._phonon_supercell_symmetry,
+                symprec=self._symprec,
                 log_level=self._log_level,
             )
         else:

--- a/phono3py/cui/phono3py_argparse.py
+++ b/phono3py/cui/phono3py_argparse.py
@@ -714,6 +714,13 @@ def get_parser(fc_symmetry=False, is_nac=False, load_phono3py_yaml=False):
         help="Cutoff width of smearing function (ratio to sigma value)",
     )
     parser.add_argument(
+        "--symfc",
+        dest="use_symfc",
+        action="store_true",
+        default=None,
+        help="Use symfc for generating force constants",
+    )
+    parser.add_argument(
         "--spf",
         dest="is_spectral_function",
         action="store_true",

--- a/phono3py/interface/fc_calculator.py
+++ b/phono3py/interface/fc_calculator.py
@@ -34,16 +34,26 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+from phonopy.structure.atoms import PhonopyAtoms
+from phonopy.structure.cells import Primitive
+from phonopy.structure.symmetry import Symmetry
+
 
 def get_fc3(
-    supercell,
-    primitive,
-    displacements,
-    forces,
-    fc_calculator=None,
-    fc_calculator_options=None,
-    is_compact_fc=False,
-    log_level=0,
+    supercell: PhonopyAtoms,
+    primitive: Primitive,
+    displacements: np.ndarray,
+    forces: np.ndarray,
+    fc_calculator: Optional[str] = None,
+    fc_calculator_options: Optional[str] = None,
+    is_compact_fc: bool = False,
+    symmetry: Optional[Symmetry] = None,
+    log_level: int = 0,
 ):
     """Supercell 2nd order force constants (fc2) are calculated.
 
@@ -86,15 +96,28 @@ def get_fc3(
 
     """
     if fc_calculator == "alm":
-        from phono3py.interface.alm import get_fc3
+        from phono3py.interface.alm import get_fc3 as get_fc3_alm
 
-        return get_fc3(
+        return get_fc3_alm(
             supercell,
             primitive,
             displacements,
             forces,
             options=fc_calculator_options,
             is_compact_fc=is_compact_fc,
+            log_level=log_level,
+        )
+    elif fc_calculator == "symfc":
+        from phonopy.interface.symfc import run_symfc
+
+        return run_symfc(
+            supercell,
+            primitive,
+            displacements,
+            forces,
+            orders=[2, 3],
+            is_compact_fc=is_compact_fc,
+            symmetry=symmetry,
             log_level=log_level,
         )
     else:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -170,21 +170,21 @@ def si_pbesol_111(request) -> Phono3py:
 
 
 @pytest.fixture(scope="session")
-def si_pbesol_111_alm(request) -> Phono3py:
+def si_pbesol_111_symfc(request) -> Phono3py:
     """Return Phono3py instance of Si 1x1x1.
 
     * with symmetry
     * full fc
-    * use alm if available on test side
+    * use symfc if available on test side
 
     """
-    pytest.importorskip("alm")
+    pytest.importorskip("symfc")
 
     yaml_filename = cwd / "phono3py_params_Si111.yaml"
     enable_v2 = request.config.getoption("--v2")
     return phono3py.load(
         yaml_filename,
-        fc_calculator="alm",
+        fc_calculator="symfc",
         make_r0_average=not enable_v2,
         log_level=1,
     )
@@ -208,7 +208,7 @@ def si_pbesol_111_222_fd(request) -> Phono3py:
 
     * with symmetry
     * full fc
-    * use alm if available on test side
+    * use symfc if available on test side
 
     """
     yaml_filename = cwd / "phono3py_params_Si-111-222.yaml"
@@ -221,63 +221,63 @@ def si_pbesol_111_222_fd(request) -> Phono3py:
 
 
 @pytest.fixture(scope="session")
-def si_pbesol_111_222_alm(request) -> Phono3py:
+def si_pbesol_111_222_symfc(request) -> Phono3py:
     """Return Phono3py instance of Si 1x1x1.
 
     * with symmetry
     * full fc
-    * use alm if available on test side
+    * use symfc if available on test side
 
     """
-    pytest.importorskip("alm")
+    pytest.importorskip("symfc")
 
     yaml_filename = cwd / "phono3py_params_Si-111-222.yaml"
     enable_v2 = request.config.getoption("--v2")
     return phono3py.load(
         yaml_filename,
-        fc_calculator="alm",
+        fc_calculator="symfc",
         make_r0_average=not enable_v2,
         log_level=1,
     )
 
 
 @pytest.fixture(scope="session")
-def si_pbesol_111_222_alm_fd(request) -> Phono3py:
+def si_pbesol_111_222_symfc_fd(request) -> Phono3py:
     """Return Phono3py instance of Si 1x1x1.
 
     * with symmetry
     * full fc
-    * use alm for fc2 if available on test side
+    * use symfc for fc2 if available on test side
 
     """
-    pytest.importorskip("alm")
+    pytest.importorskip("symfc")
 
     yaml_filename = cwd / "phono3py_params_Si-111-222.yaml"
     enable_v2 = request.config.getoption("--v2")
     return phono3py.load(
         yaml_filename,
-        fc_calculator="alm|",
+        fc_calculator="symfc|",
         make_r0_average=not enable_v2,
         log_level=1,
     )
 
 
 @pytest.fixture(scope="session")
-def si_pbesol_111_222_fd_alm(request) -> Phono3py:
+def si_pbesol_111_222_fd_symfc(request) -> Phono3py:
     """Return Phono3py instance of Si 1x1x1.
 
     * with symmetry
     * full fc
-    * use alm for fc3 if available on test side
+    * use symfc for fc3 if available on test side
 
     """
-    pytest.importorskip("alm")
+    pytest.importorskip("symfc")
 
     yaml_filename = cwd / "phono3py_params_Si-111-222.yaml"
     enable_v2 = request.config.getoption("--v2")
     return phono3py.load(
         yaml_filename,
-        fc_calculator="|alm",
+        fc_calculator="|symfc",
         make_r0_average=not enable_v2,
         log_level=1,
     )

--- a/test/cui/test_phono3py_load_script.py
+++ b/test/cui/test_phono3py_load_script.py
@@ -65,12 +65,10 @@ def test_phono3py_load():
             file_path.unlink()
 
 
-@pytest.mark.parametrize("fc_calculator,exit_code", [(None, 1), ("alm", 0)])
+@pytest.mark.parametrize("fc_calculator,exit_code", [(None, 1), ("symfc", 0)])
 def test_phono3py_load_with_typeII_dataset(fc_calculator, exit_code):
     """Test phono3py-load script with typeII dataset."""
-    # Check sys.exit(0)
-    if fc_calculator == "alm":
-        pytest.importorskip("alm")
+    pytest.importorskip("symfc")
     argparse_control = _get_phono3py_load_args(
         cwd / ".." / "phono3py_params-Si111-rd.yaml.xz", fc_calculator=fc_calculator
     )

--- a/test/phonon3/test_displacements.py
+++ b/test/phonon3/test_displacements.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 import phono3py
+from phono3py import Phono3py
 from phono3py.phonon3.displacement_fc3 import get_smallest_vector_of_atom_pair
 
 distances_NaCl = [
@@ -97,9 +98,13 @@ def test_duplicates_agno2(agno2_cell):
     np.testing.assert_equal(duplicates_ref, ph3.dataset["duplicates"])
 
 
-def test_nacl_pbe(nacl_pbe):
+def test_nacl_pbe(nacl_pbe: Phono3py):
     """Test generated displacements and duplicates."""
-    ph3 = nacl_pbe
+    ph3 = Phono3py(
+        nacl_pbe.unitcell,
+        supercell_matrix=nacl_pbe.supercell_matrix,
+        primitive_matrix=nacl_pbe.primitive_matrix,
+    )
     ph3.generate_displacements()
     duplicates_ref = [[77, 41]]
     ph3.dataset["duplicates"]

--- a/test/phonon3/test_fc3.py
+++ b/test/phonon3/test_fc3.py
@@ -127,9 +127,9 @@ def test_phonon_smat_fd(si_pbesol_111_222_fd: Phono3py):
     np.testing.assert_allclose(ph.fc2[0, 33], fc2_ref, atol=1e-6, rtol=0)
 
 
-def test_phonon_smat_alm(si_pbesol_111_222_alm: Phono3py):
-    """Test phonon smat and ALM with Si PBEsol 1x1x1-2x2x2."""
-    ph = si_pbesol_111_222_alm
+def test_phonon_smat_symfc(si_pbesol_111_222_symfc: Phono3py):
+    """Test phonon smat and symfc with Si PBEsol 1x1x1-2x2x2."""
+    ph = si_pbesol_111_222_symfc
     fc3_ref = [
         [
             [0.10725082, 0.0, 0.0],
@@ -156,9 +156,9 @@ def test_phonon_smat_alm(si_pbesol_111_222_alm: Phono3py):
     np.testing.assert_allclose(ph.fc2[0, 33], fc2_ref, atol=1e-6, rtol=0)
 
 
-def test_phonon_smat_alm_fd(si_pbesol_111_222_alm_fd: Phono3py):
-    """Test phonon smat and ALM (fc2) FD (fc3) with Si PBEsol 1x1x1-2x2x2."""
-    ph = si_pbesol_111_222_alm_fd
+def test_phonon_smat_symfc_fd(si_pbesol_111_222_symfc_fd: Phono3py):
+    """Test phonon smat and symfc (fc2) FD (fc3) with Si PBEsol 1x1x1-2x2x2."""
+    ph = si_pbesol_111_222_symfc_fd
     fc3_ref = [
         [
             [1.07250822e-01, 1.86302073e-17, -4.26452855e-18],
@@ -185,9 +185,9 @@ def test_phonon_smat_alm_fd(si_pbesol_111_222_alm_fd: Phono3py):
     np.testing.assert_allclose(ph.fc2[0, 33], fc2_ref, atol=1e-6, rtol=0)
 
 
-def test_phonon_smat_fd_alm(si_pbesol_111_222_fd_alm: Phono3py):
-    """Test phonon smat and FD (fc2) ALM (fc3) with Si PBEsol 1x1x1-2x2x2."""
-    ph = si_pbesol_111_222_fd_alm
+def test_phonon_smat_fd_symfc(si_pbesol_111_222_fd_symfc: Phono3py):
+    """Test phonon smat and FD (fc2) symfc (fc3) with Si PBEsol 1x1x1-2x2x2."""
+    ph = si_pbesol_111_222_fd_symfc
     fc3_ref = [
         [
             [0.10725082, 0.0, 0.0],
@@ -215,14 +215,14 @@ def test_phonon_smat_fd_alm(si_pbesol_111_222_fd_alm: Phono3py):
 
 
 def test_phonon_smat_alm_cutoff(si_pbesol_111_222_alm_cutoff: Phono3py):
-    """Test phonon smat and ALM with Si PBEsol 1x1x1-2x2x2 cutoff."""
+    """Test phonon smat and alm with Si PBEsol 1x1x1-2x2x2 cutoff."""
     ph = si_pbesol_111_222_alm_cutoff
     np.testing.assert_allclose(ph.fc3[0, 1, 7], 0, atol=1e-6, rtol=0)
     np.testing.assert_allclose(ph.fc2[0, 33], 0, atol=1e-6, rtol=0)
 
 
 def test_phonon_smat_alm_cutoff_fc2(si_pbesol_111_222_alm_cutoff_fc2: Phono3py):
-    """Test phonon smat and ALM with Si PBEsol 1x1x1-2x2x2 cutoff fc2."""
+    """Test phonon smat and alm with Si PBEsol 1x1x1-2x2x2 cutoff fc2."""
     ph = si_pbesol_111_222_alm_cutoff_fc2
     fc3_ref = [
         [
@@ -246,7 +246,7 @@ def test_phonon_smat_alm_cutoff_fc2(si_pbesol_111_222_alm_cutoff_fc2: Phono3py):
 
 
 def test_phonon_smat_alm_cutoff_fc3(si_pbesol_111_222_alm_cutoff_fc3: Phono3py):
-    """Test phonon smat and ALM with Si PBEsol 1x1x1-2x2x2 cutoff fc3."""
+    """Test phonon smat and alm with Si PBEsol 1x1x1-2x2x2 cutoff fc3."""
     ph = si_pbesol_111_222_alm_cutoff_fc3
     np.testing.assert_allclose(ph.fc3[0, 1, 7], 0, atol=1e-6, rtol=0)
     fc2_ref = [
@@ -293,10 +293,9 @@ def test_fc3_lapacke_solver(si_pbesol_111: Phono3py, pinv_solver: str):
     np.testing.assert_allclose(fc3[0, 1, 7], fc3_ref, atol=1e-8, rtol=0)
 
 
-# @pytest.mark.skipif(not FC_CALCULATOR_ALM_AVAILABLE, reason="not found ALM package")
-def test_fc3_alm(si_pbesol_111_alm: Phono3py):
-    """Test fc3 with Si PBEsol 1x1x1 calcualted using ALM."""
-    ph = si_pbesol_111_alm
+def test_fc3_symfc(si_pbesol_111_symfc: Phono3py):
+    """Test fc3 with Si PBEsol 1x1x1 calcualted using symfc."""
+    ph = si_pbesol_111_symfc
     fc3_ref = [
         [
             [0.10725082233069763, 0.0, 0.0],

--- a/test/sscha/test_sscha.py
+++ b/test/sscha/test_sscha.py
@@ -277,13 +277,12 @@ def _test_disp_corr_matrix(ph3):
 
 def test_fc3(si_pbesol_iterha_111):
     """Test of ThirdOrderFC class."""
-    try:
-        import alm  # noqa F401
-    except ModuleNotFoundError:
-        pytest.skip("Skip this test because ALM module was not found.")
+    pytest.importorskip("symfc")
 
     ph = si_pbesol_iterha_111
-    ph.produce_force_constants(calculate_full_force_constants=True, fc_calculator="alm")
+    ph.produce_force_constants(
+        calculate_full_force_constants=True, fc_calculator="symfc"
+    )
     supercell_phonon = SupercellPhonon(
         ph.supercell,
         ph.force_constants,


### PR DESCRIPTION
Symfc can be used to calculate supercell fc3.

* Added `--symfc` option.
* Cutoff distance is not supported yet.
* Most of tests with ALM were replaced by those using symfc except for those using cutoff distance.