### PR TITLE
Wien2k support

### DIFF
--- a/phono3py/cui/create_force_sets.py
+++ b/phono3py/cui/create_force_sets.py
@@ -50,6 +50,7 @@ from phonopy.cui.load_helper import get_nac_params
 from phonopy.cui.phonopy_script import file_exists, files_exist, print_error
 from phonopy.file_IO import is_file_phonopy_yaml, parse_FORCE_SETS, write_FORCE_SETS
 from phonopy.interface.calculator import get_calc_dataset
+from phono3py.interface.wien2k import get_fc3_calc_dataset_wien2k
 from phonopy.structure.atoms import PhonopyAtoms
 
 from phono3py.cui.settings import Phono3pySettings
@@ -385,12 +386,23 @@ def _get_force_sets_fc3(
     ):  # type-1
         calc_dataset = {"forces": []}
     else:  # type-2
-        calc_dataset = get_calc_dataset(
-            interface_mode,
-            num_atoms,
-            force_filenames,
-            verbose=(log_level > 0),
-        )
+        if interface_mode == "wien2k":
+            calc_dataset = get_fc3_calc_dataset_wien2k(
+
+                force_filenames,
+                supercell,
+                disp_dataset,
+#                wien2k_P1_mode=wien2k_P1_mode,
+#                symmetry_tolerance=symmetry_tolerance,
+                verbose=(log_level > 0),
+            )
+        else:
+            calc_dataset = get_calc_dataset(
+                interface_mode,
+                num_atoms,
+                force_filenames,
+                verbose=(log_level > 0),
+            )
         force_sets = calc_dataset["forces"]
         if "points" in calc_dataset:
             if filename := check_agreements_of_displacements(

--- a/phono3py/cui/create_force_sets.py
+++ b/phono3py/cui/create_force_sets.py
@@ -50,7 +50,6 @@ from phonopy.cui.load_helper import get_nac_params
 from phonopy.cui.phonopy_script import file_exists, files_exist, print_error
 from phonopy.file_IO import is_file_phonopy_yaml, parse_FORCE_SETS, write_FORCE_SETS
 from phonopy.interface.calculator import get_calc_dataset
-from phono3py.interface.wien2k import get_fc3_calc_dataset_wien2k
 from phonopy.structure.atoms import PhonopyAtoms
 
 from phono3py.cui.settings import Phono3pySettings
@@ -64,6 +63,7 @@ from phono3py.interface.phono3py_yaml import (
     Phono3pyYaml,
     displacements_yaml_lines_type1,
 )
+from phono3py.interface.wien2k import get_fc3_calc_dataset_wien2k
 
 
 def create_FORCES_FC3_and_FORCES_FC2(
@@ -388,12 +388,11 @@ def _get_force_sets_fc3(
     else:  # type-2
         if interface_mode == "wien2k":
             calc_dataset = get_fc3_calc_dataset_wien2k(
-
                 force_filenames,
                 supercell,
                 disp_dataset,
-#                wien2k_P1_mode=wien2k_P1_mode,
-#                symmetry_tolerance=symmetry_tolerance,
+                #                wien2k_P1_mode=wien2k_P1_mode,
+                #                symmetry_tolerance=symmetry_tolerance,
                 verbose=(log_level > 0),
             )
         else:

--- a/phono3py/interface/calculator.py
+++ b/phono3py/interface/calculator.py
@@ -50,8 +50,8 @@ calculator_info = {
     #                       'help': "Invoke Siesta mode"}},
     "turbomole": {"option": {"name": "--turbomole", "help": "Invoke TURBOMOLE mode"}},
     "vasp": {"option": {"name": "--vasp", "help": "Invoke Vasp mode"}},
-    # 'wien2k': {'option': {'name': "--wien2k",
-    #                       'help': "Invoke Wien2k mode"}},
+    "wien2k": {"option": {"name": "--wien2k",
+                           "help": "Invoke Wien2k mode"}},
 }
 
 

--- a/phono3py/interface/calculator.py
+++ b/phono3py/interface/calculator.py
@@ -50,8 +50,7 @@ calculator_info = {
     #                       'help': "Invoke Siesta mode"}},
     "turbomole": {"option": {"name": "--turbomole", "help": "Invoke TURBOMOLE mode"}},
     "vasp": {"option": {"name": "--vasp", "help": "Invoke Vasp mode"}},
-    "wien2k": {"option": {"name": "--wien2k",
-                           "help": "Invoke Wien2k mode"}},
+    "wien2k": {"option": {"name": "--wien2k", "help": "Invoke Wien2k mode"}},
 }
 
 

--- a/phono3py/interface/wien2k.py
+++ b/phono3py/interface/wien2k.py
@@ -34,7 +34,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from phono3py.phonon3.dataset import get_displacements_fc3, get_displacements_and_forces_fc3
+from phono3py.phonon3.dataset import get_displacements_fc3
 
 
 def get_fc3_calc_dataset_wien2k(
@@ -48,7 +48,7 @@ def get_fc3_calc_dataset_wien2k(
     """Read Wien2k output files and parse force sets."""
     from phonopy.interface.wien2k import parse_set_of_forces
 
-#    disps, _ = get_displacements_and_forces_fc3(disp_dataset)
+    #    disps, _ = get_displacements_and_forces_fc3(disp_dataset)
     disps = get_displacements_fc3(disp_dataset)
     force_sets = parse_set_of_forces(
         disps,

--- a/phono3py/interface/wien2k.py
+++ b/phono3py/interface/wien2k.py
@@ -1,0 +1,61 @@
+"""ALM interface for force constants calculation."""
+
+# Copyright (C) 2016 Atsushi Togo
+# All rights reserved.
+#
+# This file is part of phono3py.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+#
+# * Neither the name of the phonopy project nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from phono3py.phonon3.dataset import get_displacements_fc3, get_displacements_and_forces_fc3
+
+
+def get_fc3_calc_dataset_wien2k(
+    force_filenames,
+    supercell,
+    disp_dataset,
+    wien2k_P1_mode=False,
+    symmetry_tolerance=None,
+    verbose=False,
+):
+    """Read Wien2k output files and parse force sets."""
+    from phonopy.interface.wien2k import parse_set_of_forces
+
+#    disps, _ = get_displacements_and_forces_fc3(disp_dataset)
+    disps = get_displacements_fc3(disp_dataset)
+    force_sets = parse_set_of_forces(
+        disps,
+        force_filenames,
+        supercell,
+        wien2k_P1_mode=wien2k_P1_mode,
+        symmetry_tolerance=symmetry_tolerance,
+        verbose=verbose,
+    )
+    return {"forces": force_sets}

--- a/phono3py/phonon3/dataset.py
+++ b/phono3py/phonon3/dataset.py
@@ -97,6 +97,7 @@ def get_displacements_and_forces_fc3(disp_dataset):
     else:
         raise RuntimeError("disp_dataset doesn't contain correct information.")
 
+
 def get_displacements_fc3(disp_dataset):
     """Return displacements and forces from disp_dataset.
 
@@ -121,13 +122,13 @@ def get_displacements_fc3(disp_dataset):
 
     """
     if "first_atoms" in disp_dataset:
-        natom = disp_dataset["natom"]    
-        ndisp = len(disp_dataset["first_atoms"])     
+        natom = disp_dataset["natom"]
+        ndisp = len(disp_dataset["first_atoms"])
         for disp1 in disp_dataset["first_atoms"]:
             ndisp += len(disp1["second_atoms"])
         displacements = np.zeros((ndisp, natom, 3), dtype="double", order="C")
         indices = []
-        count = 0       
+        count = 0
         for disp1 in disp_dataset["first_atoms"]:
             indices.append(count)
             displacements[count, disp1["number"]] = disp1["displacement"]
@@ -143,13 +144,14 @@ def get_displacements_fc3(disp_dataset):
                 displacements[count, disp1["number"]] = disp1["displacement"]
                 displacements[count, disp2["number"]] = disp2["displacement"]
                 count += 1
-                   
+
         return np.array(displacements[indices], dtype="double", order="C")
- 
-    elif "forces" in disp_dataset and "displacements" in disp_dataset:           
+
+    elif "forces" in disp_dataset and "displacements" in disp_dataset:
         return disp_dataset["displacements"]
-    else:            
-        raise RuntimeError("disp_dataset doesn't contain correct information.")   
+    else:
+        raise RuntimeError("disp_dataset doesn't contain correct information.")
+
 
 def forces_in_dataset(dataset: Optional[dict]) -> bool:
     """Return whether forces in dataset or not."""

--- a/phono3py/phonon3/dataset.py
+++ b/phono3py/phonon3/dataset.py
@@ -97,6 +97,59 @@ def get_displacements_and_forces_fc3(disp_dataset):
     else:
         raise RuntimeError("disp_dataset doesn't contain correct information.")
 
+def get_displacements_fc3(disp_dataset):
+    """Return displacements and forces from disp_dataset.
+
+    Note
+    ----
+    Dipslacements and forces of all atoms in supercells are returned.
+
+    Parameters
+    ----------
+    disp_dataset : dict
+        Displacement dataset.
+
+    Returns
+    -------
+    displacements : ndarray
+        Displacements of all atoms in all supercells.
+        shape=(snapshots, supercell atoms, 3), dtype='double', order='C'
+    forces : ndarray or None
+        Forces of all atoms in all supercells.
+        shape=(snapshots, supercell atoms, 3), dtype='double', order='C'
+        None is returned when forces don't exist.
+
+    """
+    if "first_atoms" in disp_dataset:
+        natom = disp_dataset["natom"]    
+        ndisp = len(disp_dataset["first_atoms"])     
+        for disp1 in disp_dataset["first_atoms"]:
+            ndisp += len(disp1["second_atoms"])
+        displacements = np.zeros((ndisp, natom, 3), dtype="double", order="C")
+        indices = []
+        count = 0       
+        for disp1 in disp_dataset["first_atoms"]:
+            indices.append(count)
+            displacements[count, disp1["number"]] = disp1["displacement"]
+            count += 1
+
+        for disp1 in disp_dataset["first_atoms"]:
+            for disp2 in disp1["second_atoms"]:
+                if "included" in disp2:
+                    if disp2["included"]:
+                        indices.append(count)
+                else:
+                    indices.append(count)
+                displacements[count, disp1["number"]] = disp1["displacement"]
+                displacements[count, disp2["number"]] = disp2["displacement"]
+                count += 1
+                   
+        return np.array(displacements[indices], dtype="double", order="C")
+ 
+    elif "forces" in disp_dataset and "displacements" in disp_dataset:           
+        return disp_dataset["displacements"]
+    else:            
+        raise RuntimeError("disp_dataset doesn't contain correct information.")   
 
 def forces_in_dataset(dataset: Optional[dict]) -> bool:
     """Return whether forces in dataset or not."""


### PR DESCRIPTION
Support of wien2k code added to phono3py with this fork.
Changes have been made to the following files:

        modified:   phono3py/cui/create_force_sets.py
        modified:   phono3py/interface/calculator.py
        modified:   phono3py/phonon3/dataset.py

Also, new interface have been added:
        phono3py/interface/wien2k.py

Define constant `force_to_eVperA` for wien2k in phonopy needs (the corresponding pull request was made in the phonopy repository):
`        units["force_to_eVperA"] = 0.001 * Rydberg / Bohr`

