### PR TITLE
Update github workflows for no-lapacke as default

### DIFF
--- a/.github/workflows/phono3py-pytest-conda-mkl-phphmtblas.yml
+++ b/.github/workflows/phono3py-pytest-conda-mkl-phphmtblas.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install phono3py
       run: |
         conda activate test
-        PHPHCALC_USE_MTBLAS=ON pip install -e . -vvv
+        BUILD_WITHOUT_LAPACKE=OFF PHPHCALC_USE_MTBLAS=ON pip install -e . -vvv
     - name: Run pytest
       run: |
         conda activate test

--- a/.github/workflows/phono3py-pytest-conda-mkl-phphmtblas.yml
+++ b/.github/workflows/phono3py-pytest-conda-mkl-phphmtblas.yml
@@ -1,4 +1,4 @@
-name: Pytest with mkl  sing BLAS for phph-calc
+name: Pytest with mkl using BLAS for phph-calc
 
 on:
   pull_request:

--- a/.github/workflows/phono3py-pytest-conda-mkl-v2.yml
+++ b/.github/workflows/phono3py-pytest-conda-mkl-v2.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install phono3py
       run: |
         conda activate test
-        pip install -e . -vvv
+        BUILD_WITHOUT_LAPACKE=OFF pip install -e . -vvv
     - name: Run pytest
       run: |
         conda activate test

--- a/.github/workflows/phono3py-pytest-conda-mkl.yml
+++ b/.github/workflows/phono3py-pytest-conda-mkl.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Run pytest
       run: |
         conda activate test
-        pytest -v --cov=./ --cov-report=xml test
+        BUILD_WITHOUT_LAPACKE=OFF pytest -v --cov=./ --cov-report=xml test
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/phono3py-pytest-conda-phphmtblas.yml
+++ b/.github/workflows/phono3py-pytest-conda-phphmtblas.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install phono3py
       run: |
         conda activate test
-        PHPHCALC_USE_MTBLAS=ON pip install -e . -vvv
+        BUILD_WITHOUT_LAPACKE=OFF PHPHCALC_USE_MTBLAS=ON pip install -e . -vvv
     - name: Run pytest
       run: |
         conda activate test

--- a/.github/workflows/phono3py-pytest-conda-with-lapacke.yml
+++ b/.github/workflows/phono3py-pytest-conda-with-lapacke.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         conda activate test
         conda install --yes python=${{ matrix.python-version }}
-        conda install --yes matplotlib-base pyyaml h5py scipy pytest spglib cmake c-compiler cxx-compiler
+        conda install --yes matplotlib-base pyyaml "libblas=*=*openblas" openblas h5py scipy pytest spglib cmake c-compiler cxx-compiler
     - name: Install symfc develop branch
       run: |
         conda activate test
@@ -42,7 +42,7 @@ jobs:
     - name: Install phono3py
       run: |
         conda activate test
-        BUILD_WITHOUT_LAPACKE=ON pip install -e . -vvv
+        BUILD_WITHOUT_LAPACKE=OFF pip install -e . -vvv
     - name: Run pytest
       run: |
         conda activate test

--- a/.github/workflows/phono3py-pytest-conda-with-lapacke.yml
+++ b/.github/workflows/phono3py-pytest-conda-with-lapacke.yml
@@ -1,4 +1,4 @@
-name: Pytest without linking BLAS and LAPACK in C
+name: Pytest with linking BLAS and LAPACK in C
 
 on:
   pull_request:

--- a/.github/workflows/phono3py-pytest-conda.yml
+++ b/.github/workflows/phono3py-pytest-conda.yml
@@ -1,4 +1,4 @@
-name: Pytest with openblas
+name: Pytest without using LAPACKE
 
 on:
   pull_request:

--- a/.github/workflows/phono3py-pytest-conda.yml
+++ b/.github/workflows/phono3py-pytest-conda.yml
@@ -25,13 +25,13 @@ jobs:
       run: |
         conda activate test
         conda install --yes python=${{ matrix.python-version }}
-        conda install --yes matplotlib-base pyyaml "libblas=*=*openblas" openblas h5py "numpy>=2.1" scipy pytest spglib alm cmake c-compiler cxx-compiler pypolymlp
+        conda install --yes matplotlib-base pyyaml h5py "numpy>=2.1" scipy pytest spglib alm cmake c-compiler cxx-compiler pypolymlp
     - name: Install dependent packages for python == 3.9
       if: ${{ matrix.python-version == 3.9 }}
       run: |
         conda activate test
         conda install --yes python=${{ matrix.python-version }}
-        conda install --yes matplotlib-base pyyaml "libblas=*=*openblas" openblas h5py scipy pytest spglib alm cmake c-compiler cxx-compiler
+        conda install --yes matplotlib-base pyyaml h5py scipy pytest spglib alm cmake c-compiler cxx-compiler
     - name: Install symfc develop branch
       run: |
         conda activate test

--- a/doc/direct-solution.md
+++ b/doc/direct-solution.md
@@ -295,24 +295,23 @@ language implementation through the python C-API.
 
 ## Solver choice for diagonalization
 
-For larger systems, diagonalization of collision matrix takes longest time and
-requires large memory space. Phono3py relies on LAPACK for the diagonalization
-and so the performance is dependent on the choice of the diagonalization solver.
+Diagonalizing the collision matrix for larger systems is the most time-consuming
+step and requires significant memory. Phono3py uses LAPACK for diagonalization,
+making performance highly dependent on the solver choice. Utilizing
+multithreaded BLAS on many-core nodes can significantly reduce computation time,
+allowing calculations to complete within practical limits. Currently, Phono3py
+supports diagonalization via scipy, numpy, and LAPACKE as LAPACK wrappers.
 
-Using multithreaded BLAS with many-core computing node, computing time may be
-well reduced and the calculation can finish in a realistic time. Currently
-scipy, numpy and LAPACKE can be used as the LAPACK wrapper in phono3py. Scipy
-and numpy distributed by anaconda are MKL linked, therefore MKL multithread BLAS
-is used through them. Multithreaded OpenBLAS is installed by conda and can be
-used via LAPACKE in phono3py. MKL LAPACK and BLAS are also able to be used via
-LAPACKE in phono3py with appropriate setting in `setup.py`.
+The default choice of the diagonalization solver is `scipy.linalg.lapack.dsyev`
+(`--pinv-solver=4`). Using `--pinv-solver NUMBER`, one of the following solvers
+is specified:
 
-Using `--pinv-solver NUMBER`, one of the following solver is chosen:
-
-1. Lapacke `dsyev`: Smaller memory consumption than `dsyevd`, but slower. This
+1. (Only available when {ref}`compiling with LAPACKE <install_with_lapacke>`)
+   Lapacke `dsyev`: Smaller memory consumption than `dsyevd`, but slower. This
    is the default solver when MKL LAPACKE is integrated or scipy is not
    installed.
-2. Lapacke `dsyevd`: Larger memory consumption than `dsyev`, but faster. This is
+2. (Only available when {ref}`compiling with LAPACKE <install_with_lapacke>`)
+   Lapacke `dsyevd`: Larger memory consumption than `dsyev`, but faster. This is
    not considered as stable as `dsyev` but can be significantly faster than
    `dsyev` for solving large collision matrix. It is recommended to compare the
    result with that by `dsyev` solver using smaller collision matrix (e.g.,
@@ -323,8 +322,3 @@ Using `--pinv-solver NUMBER`, one of the following solver is chosen:
    LAPACKE is not integrated.
 5. Scipy's `dsyevd`: Similar to solver (2), this solver should be used
    carefully.
-
-```{note}
-`pinv-solver` =3, 4, and 5 are only available when phono3py is compiled
-without LAPACKE.
-```

--- a/doc/install.md
+++ b/doc/install.md
@@ -41,8 +41,9 @@ removed.
 If phono3py is compiled with a special compiler or special options, manual
 modification of `CMakeLists.txt` may be needed.
 
-- {ref}`Linear algebra library <install_lapacke>`: BLAS, LAPACK, and LAPACKE
 - {ref}`OpenMP library <install_openmp>`: For the multithreding support.
+- {ref}`Linear algebra library <install_lapacke>`: BLAS, LAPACK, and LAPACKE
+  (optional, see {ref}`install_with_lapacke`)
 
 These packages may be installed by the package manager of OS (e.g. `apt`) or
 conda environment. Automatic search of required libraries and flags that are
@@ -60,24 +61,6 @@ This phono3py build can be launched by
 See an example at {ref}`install_an_example`. In the standard output, flags and
 libraries found by cmake are shown. Please carefully check if those
 configurations are expected ones or not.
-
-(install_without_lapacke)=
-### Building without linking LAPACKE
-
-**Experimental**
-
-To compile phono3py without linking LAPACKE in C, use the following command:
-
-```
-% BUILD_WITHOUT_LAPACKE=ON pip install -e . -vvv
-```
-
-When this option is enabled, linking to BLAS and LAPACKE libraries is not
-required, so installing these libraries for C compilation may not be necessary.
-However, since numpy and scipy rely on BLAS and LAPACK libraries, their runtime
-versions are still required.
-
-(install_an_example)=
 
 ## Installation instruction of latest development version of phono3py
 
@@ -122,7 +105,7 @@ wrong python libraries can be imported.
    % conda install numpy scipy h5py pyyaml matplotlib-base c-compiler cxx-compiler cmake spglib
    ```
 
-   Unless {ref}`install_without_lapacke`, the following packages will be
+   Unless {ref}`install_with_lapacke`, the following packages will be
    necessary to compile phono3py:
 
    ```bash
@@ -142,7 +125,7 @@ wrong python libraries can be imported.
    % conda install numpy scipy h5py pyyaml matplotlib-base c-compiler cxx-compiler spglib cmake
    ```
 
-   Unless {ref}`install_without_lapacke`, the following package will be
+   Unless {ref}`install_with_lapacke`, the following package will be
    necessary to compile phono3py:
 
    ```bash
@@ -184,6 +167,27 @@ LAPACK library is used in a few parts of the code to diagonalize matrices.
 LAPACK*E* is the C-wrapper of LAPACK and LAPACK relies on BLAS. Both
 single-thread or multithread BLAS can be used in phono3py. In the following,
 multiple different ways of installation of LAPACKE are explained.
+
+(install_with_lapacke)=
+#### Building with linking LAPACKE
+
+Phono3py can operate without linking to LAPACKE, which is the default
+compilation setting. However, it is also possible to compile Phono3py with
+LAPACKE support. When compiled this way, the diagonalization of the dynamical
+matrix is handled by LAPACK routines within the C code of Phono3py.
+Additionally, LAPACK is used for the diagonalization of the collision matrix
+in the direct solution.
+
+To compile phono3py with linking LAPACKE in C, use the following command:
+
+```
+% BUILD_WITHOUT_LAPACKE=OFF pip install -e . -vvv
+```
+
+For this, BLAS and LAPACKE libraries are required.
+
+(install_an_example)=
+
 
 #### OpenBLAS provided by conda
 


### PR DESCRIPTION
GitHub workflows for running tests have been updated to reflect the default compilation without LAPACKE.