### PR TITLE
macOS + Windows wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: wheel-build-and-deploy
+name: Build and publish wheels
 
 on:
   push:
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.os }} wheels for Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        # os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
+        python-version: ["310", "311", "312"]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,25 +29,20 @@ jobs:
           git tag v`grep __version__ phono3py/version.py|awk -F'"' '{print($2)}'`
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "cp39-* pp* *_i686 *musllinux*"
+          CIBW_BUILD: cp${{ matrix.python-version }}-*
+          CIBW_SKIP: "pp* *_i686 *musllinux*"
           CIBW_BUILD_VERBOSITY: 1
-
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
+          CIBW_ARCHS_MACOS: universal2
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}-${{ matrix.python-version }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   upload_pypi_test:
-    name: Upload to PyPI (test)
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    name: Upload to TestPyPI
     needs: [build_wheels]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel-test')
     steps:
       - uses: actions/download-artifact@v4
@@ -55,20 +50,19 @@ jobs:
           pattern: cibw-wheels-*
           path: dist
           merge-multiple: true
+
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
+          verbose: true
 
   upload_pypi:
     name: Upload to PyPI
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
     needs: [build_wheels]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel')
     steps:
       - uses: actions/download-artifact@v4
@@ -76,8 +70,10 @@ jobs:
           pattern: cibw-wheels-*
           path: dist
           merge-multiple: true
+
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
+          verbose: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,8 +1,8 @@
 name: wheel-build-and-deploy
 
 on:
-    push:
-      branches:
+  push:
+    branches:
       - make-wheel
       - make-wheel-test
 
@@ -12,73 +12,72 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,]
+        os: [ubuntu-latest]
         # os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
 
-
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    # Used to host cibuildwheel
-    - uses: actions/setup-python@v5
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
 
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==2.22.0
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.22.0
 
-    - name: Build wheels
-      run: |
-        git tag v`grep __version__ phono3py/version.py|awk -F'"' '{print($2)}'`
-        python -m cibuildwheel --output-dir wheelhouse
-      env:
-        CIBW_SKIP: "cp39-* pp* *_i686 *musllinux*"
-        CIBW_BUILD_VERBOSITY: 1
+      - name: Build wheels
+        run: |
+          git tag v`grep __version__ phono3py/version.py|awk -F'"' '{print($2)}'`
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_SKIP: "cp39-* pp* *_i686 *musllinux*"
+          CIBW_BUILD_VERBOSITY: 1
 
-      # to supply options, put them in 'env', like:
-      # env:
-      #   CIBW_SOME_OPTION: value
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-        path: ./wheelhouse/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
 
   upload_pypi_test:
     name: Upload to PyPI (test)
     strategy:
       matrix:
-        os: [ubuntu-latest,]
-    needs: [build_wheels,]
+        os: [ubuntu-latest]
+    needs: [build_wheels]
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel-test')
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: cibw-wheels-*
-        path: dist
-        merge-multiple: true
-    - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip-existing: true
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   upload_pypi:
     name: Upload to PyPI
     strategy:
       matrix:
-        os: [ubuntu-latest,]
-    needs: [build_wheels,]
+        os: [ubuntu-latest]
+    needs: [build_wheels]
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel')
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: cibw-wheels-*
-        path: dist
-        merge-multiple: true
-    - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        skip-existing: true
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
closes https://github.com/phonopy/phono3py/issues/295

@atztogo i noticed you don't directly use 

```yml
uses: pypa/cibuildwheel@v2.18.1
```
in the `build_wheels` `steps`. is that by design? i think it could replace your code

```sh
git tag v`grep __version__ phono3py/version.py|awk -F'"' '{print($2)}'`
python -m cibuildwheel --output-dir wheelhouse
```

if not and `phono3py` has special requirements i'm unaware of, then what i did (simply adding Windows and macOS to the `strategy.matrix.os`) might not work in which case, feel free to close this PR