### PR TITLE
Make wheels for test-PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,9 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,]
-        # os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        # os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +24,8 @@ jobs:
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel==2.22.0
 
-    - name: Build wheels
+    - name: Build wheels on ubuntu
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |
         git tag v`grep __version__ phono3py/version.py|awk -F'"' '{print($2)}'`
         python -m cibuildwheel --output-dir wheelhouse
@@ -33,9 +33,28 @@ jobs:
         CIBW_SKIP: "cp39-* pp* *_i686 *musllinux*"
         CIBW_BUILD_VERBOSITY: 1
 
-      # to supply options, put them in 'env', like:
-      # env:
-      #   CIBW_SOME_OPTION: value
+    - name: Build wheels on macos
+      if: ${{ startsWith(matrix.os, 'macos') }}
+      run: |
+        git tag v`grep __version__ phono3py/version.py|awk -F'"' '{print($2)}'`
+        python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_SKIP: "cp39-* pp*"
+        # CIBW_ARCHS_MACOS: "x86_64 arm64"
+        CIBW_BUILD_VERBOSITY: 1
+
+    - name: Build wheels on windows
+      if: ${{ startsWith(matrix.os, 'windows') }}
+      run: |
+        $version = Select-String -Path "phono3py\version.py" -Pattern '__version__' | ForEach-Object {
+            ($_ -split '"')[1]
+        }
+        git tag "v$version"
+        Write-Output "The value of version is: $version"
+        python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_SKIP: "cp39-* pp*"
+        CIBW_BUILD_VERBOSITY: 1
 
     - uses: actions/upload-artifact@v4
       with:
@@ -44,12 +63,9 @@ jobs:
 
   upload_pypi_test:
     name: Upload to PyPI (test)
-    strategy:
-      matrix:
-        os: [ubuntu-latest,]
     needs: [build_wheels,]
-    runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel-test')
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/make-wheel-test' }}
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -60,17 +76,14 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
         skip-existing: true
 
   upload_pypi:
     name: Upload to PyPI
-    strategy:
-      matrix:
-        os: [ubuntu-latest,]
     needs: [build_wheels,]
-    runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel')
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/make-wheel' }}
     steps:
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
This recipe is almost identical to the one for Phonopy (https://github.com/phonopy/phonopy/pull/505). However, the direct-solution method does not work on Windows, so the Windows wheels have been excluded. The exact reason why the direct-solution method fails on Windows is currently unknown. In the future, it may be possible to provide Windows wheels with the direct-solution method disabled.