### PR TITLE
Fix a bug in computing collision matrix in C

### DIFF
--- a/c/collision_matrix.c
+++ b/c/collision_matrix.c
@@ -124,9 +124,9 @@ static void get_collision_matrix(
 
     gp2tp_map = create_gp2tp_map(triplets_map, num_gp);
 
-#ifdef _OPENMP
-#pragma omp parallel for private(j, k, l, m, n, ti, r_gp, collision, inv_sinh)
-#endif
+    // #ifdef _OPENMP
+    // #pragma omp parallel for private(j, k, l, m, n, ti, r_gp, collision,
+    // inv_sinh) #endif
     for (i = 0; i < num_ir_gp; i++) {
         inv_sinh = (double *)malloc(sizeof(double) * num_band);
         for (j = 0; j < num_rot; j++) {
@@ -194,9 +194,9 @@ static void get_reducible_collision_matrix(
 
     gp2tp_map = create_gp2tp_map(triplets_map, num_gp);
 
-#ifdef _OPENMP
-#pragma omp parallel for private(j, k, l, ti, collision, inv_sinh)
-#endif
+    // #ifdef _OPENMP
+    // #pragma omp parallel for private(j, k, l, ti, collision, inv_sinh)
+    // #endif
     for (i = 0; i < num_gp; i++) {
         inv_sinh = (double *)malloc(sizeof(double) * num_band);
         ti = gp2tp_map[triplets_map[i]];

--- a/c/collision_matrix.c
+++ b/c/collision_matrix.c
@@ -124,9 +124,10 @@ static void get_collision_matrix(
 
     gp2tp_map = create_gp2tp_map(triplets_map, num_gp);
 
-    // #ifdef _OPENMP
-    // #pragma omp parallel for private(j, k, l, m, n, ti, r_gp, collision,
-    // inv_sinh) #endif
+#ifdef _OPENMP
+#pragma omp parallel for private(j, k, l, m, n, ti, r_gp, collision, inv_sinh, \
+                                     swapped)
+#endif
     for (i = 0; i < num_ir_gp; i++) {
         inv_sinh = (double *)malloc(sizeof(double) * num_band);
         for (j = 0; j < num_rot; j++) {
@@ -194,9 +195,9 @@ static void get_reducible_collision_matrix(
 
     gp2tp_map = create_gp2tp_map(triplets_map, num_gp);
 
-    // #ifdef _OPENMP
-    // #pragma omp parallel for private(j, k, l, ti, collision, inv_sinh)
-    // #endif
+#ifdef _OPENMP
+#pragma omp parallel for private(j, k, l, ti, collision, inv_sinh, swapped)
+#endif
     for (i = 0; i < num_gp; i++) {
         inv_sinh = (double *)malloc(sizeof(double) * num_band);
         ti = gp2tp_map[triplets_map[i]];

--- a/phono3py/conductivity/direct_solution.py
+++ b/phono3py/conductivity/direct_solution.py
@@ -133,7 +133,9 @@ class ConductivityLBTEBase(ConductivityBase):
 
         if self._is_reducible_collision_matrix:
             self._collision = CollisionMatrix(
-                self._pp, is_reducible_collision_matrix=True, log_level=self._log_level
+                self._pp,
+                is_reducible_collision_matrix=True,
+                log_level=self._log_level,
             )
         else:
             self._rot_grid_points = self._get_rot_grid_points()


### PR DESCRIPTION
In openmp-parallel-for, private variable of `swapped` was not made as private. The calculation in for-loop was exported to a specific function instead of including `swapped` in the list of the private variables. 