### PR TITLE
Introduce memorization in reciprocal_to_normal for optimization

### DIFF
--- a/c/reciprocal_to_normal.c
+++ b/c/reciprocal_to_normal.c
@@ -171,7 +171,7 @@ static void reciprocal_to_normal_squared_no_threading(
     const lapack_complex_double *e0, const lapack_complex_double *e1,
     const lapack_complex_double *e2, const int64_t *band_indices,
     const int64_t num_band, const double cutoff_frequency) {
-    int64_t i, j, k, ll, bi_prev, num_atom, use_multithreaded_blas;
+    int64_t i, j, k, ll, bi_prev;
     lapack_complex_double *fc3_e0, fc3_elem, zero;
 
     zero = lapack_make_complex_double(0, 0);

--- a/c/reciprocal_to_normal.c
+++ b/c/reciprocal_to_normal.c
@@ -262,6 +262,9 @@ static double get_fc3_sum(const lapack_complex_double *e1,
 
     fc3_e0_e1 = (lapack_complex_double *)malloc(sizeof(lapack_complex_double) *
                                                 num_band);
+    for (i = 0; i < num_band; i++) {
+        fc3_e0_e1[i] = lapack_make_complex_double(0, 0);
+    }
 
     for (i = 0; i < num_band; i++) {
         for (j = 0; j < num_band; j++) {

--- a/c/reciprocal_to_normal.c
+++ b/c/reciprocal_to_normal.c
@@ -185,8 +185,9 @@ static void reciprocal_to_normal_squared_no_threading(
             freqs2[g_pos[i][2]] > cutoff_frequency) {
             if (bi_prev != g_pos[i][0]) {
                 bi_prev = g_pos[i][0];
-                memset(fc3_e0, zero,
-                       sizeof(lapack_complex_double) * num_band * num_band);
+                for (j = 0; j < num_band * num_band; j++) {
+                    fc3_e0[j] = zero;
+                }
                 for (j = 0; j < num_band; j++) {
                     for (k = 0; k < num_band; k++) {
                         for (ll = 0; ll < num_band; ll++) {


### PR DESCRIPTION
This PR aims improving computational performance when without using multithreading over g. The g elements that should be computed are selected by necessity in computing lifetime in case of conductivity calculation use. What we want to compute is fc3.e0.e1.e2 in this part, and each set of (e0, e1, e2), i.e., the set of three band indices, is given sequentially in 1D for loop. In this PR, first computing and memorizing fc3.e0 and then reusing it assuming the sets of band index triplets (b0, b1, b2) change faster in right most elements, by which performance improvement is expected depending on systems.