### PR TITLE
Improve rust-impl performance

### DIFF
--- a/rust/src/imag_self_energy.rs
+++ b/rust/src/imag_self_energy.rs
@@ -14,9 +14,16 @@ use crate::funcs::bose_einstein;
 
 /// Build the non-zero entries of `g_zero` as `(band0, j, k, flat_idx)`
 /// tuples.  `g_zero` is `(num_band0, num_band, num_band)` flat for
-/// the band-index mode.  Returns the positions where `g_zero[...] == 0`.
-pub(crate) fn set_g_pos(g_zero: &[i8], num_band0: usize, num_band: usize) -> Vec<[i64; 4]> {
-    let mut out = Vec::with_capacity(g_zero.len());
+/// the band-index mode.  Writes the positions where `g_zero[...] == 0`
+/// into `out`, preserving capacity for reuse across calls.
+pub(crate) fn set_g_pos(
+    out: &mut Vec<[i64; 4]>,
+    g_zero: &[i8],
+    num_band0: usize,
+    num_band: usize,
+) {
+    out.clear();
+    out.reserve(g_zero.len());
     let mut jkl: i64 = 0;
     for j in 0..num_band0 {
         for k in 0..num_band {
@@ -28,7 +35,6 @@ pub(crate) fn set_g_pos(g_zero: &[i8], num_band0: usize, num_band: usize) -> Vec
             }
         }
     }
-    out
 }
 
 /// Frequency-point mode variant.  `g_zero` here is
@@ -226,7 +232,9 @@ pub fn get_imag_self_energy_with_g(
             let g_pos = if at_a_frequency_point {
                 set_g_pos_at_frequency_point(gz, num_band0, num_band)
             } else {
-                set_g_pos(gz, num_band0, num_band)
+                let mut g_pos = Vec::new();
+                set_g_pos(&mut g_pos, gz, num_band0, num_band);
+                g_pos
             };
             imag_self_energy_at_triplet(
                 slot,
@@ -429,7 +437,8 @@ mod tests {
         // num_band0 = 1, num_band = 2, shape (1, 2, 2) = 4 entries.
         // g_zero = [0, 1, 0, 0] -> keep indices 0, 2, 3.
         let g_zero = vec![0i8, 1, 0, 0];
-        let pos = set_g_pos(&g_zero, 1, 2);
+        let mut pos = Vec::new();
+        set_g_pos(&mut pos, &g_zero, 1, 2);
         assert_eq!(pos.len(), 3);
         assert_eq!(pos[0], [0, 0, 0, 0]);
         assert_eq!(pos[1], [0, 1, 0, 2]);

--- a/rust/src/interaction.rs
+++ b/rust/src/interaction.rs
@@ -10,7 +10,38 @@ use rayon::prelude::*;
 use crate::common::Cmplx;
 use crate::imag_self_energy::set_g_pos;
 use crate::real_to_reciprocal::{real_to_reciprocal, AtomTriplets};
-use crate::reciprocal_to_normal::reciprocal_to_normal_squared;
+use crate::reciprocal_to_normal::{reciprocal_to_normal_squared, R2NScratch};
+
+/// Per-call scratch for the interaction kernel.  Owned by the caller
+/// (typically a per-rayon-worker `for_each_init` in the multi-triplet
+/// driver) so the large `fc3_reciprocal` and `R2NScratch` buffers are
+/// allocated once per worker, then reused across the triplets that
+/// worker processes.
+#[derive(Default)]
+pub struct InteractionScratch {
+    /// Atom-first reciprocal-space fc3 buffer.  Length
+    /// `num_patom^3 * 27`.  At 56 atoms this is ~76 MiB; per-triplet
+    /// re-allocation drove allocator/page-fault overhead on many-core
+    /// runs (see RUST_PORTING.md notes for Ca(BO2)2).
+    pub fc3_reciprocal: Vec<Cmplx>,
+    /// Symmetrized 6-way path scratch: full `(num_band, num_band,
+    /// num_band)` real block.  Empty unless `symmetrize_fc3_q` is set.
+    pub sym_q_tmp: Vec<f64>,
+    /// Non-zero `g_zero` positions for the current triplet.  Capacity
+    /// up to `num_band0 * num_band^2` (~ 150 MiB at num_patom = 56).
+    /// Populated by `set_g_pos` at the start of each per-triplet kernel
+    /// and reused for the downstream `imag_self_energy_at_triplet` call
+    /// in `evaluate_collision_at_triplet`.
+    pub g_pos: Vec<[i64; 4]>,
+    /// Sub-scratch for `reciprocal_to_normal_squared`.
+    pub r2n: R2NScratch,
+}
+
+impl InteractionScratch {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 /// Fixed 6 permutations of (q0, q1, q2) used by `symmetrize_fc3_q`.
 const INDEX_EXCHANGE: [[usize; 3]; 6] = [
@@ -71,9 +102,10 @@ fn real_to_normal(
     num_patom: usize,
     cutoff_frequency: f64,
     inner_par: bool,
+    scratch: &mut InteractionScratch,
 ) {
     let fc3_recip_len = num_patom * num_patom * num_patom * 27;
-    let mut fc3_reciprocal: Vec<Cmplx> = vec![[0.0, 0.0]; fc3_recip_len];
+    scratch.fc3_reciprocal.resize(fc3_recip_len, [0.0, 0.0]);
     // NOTE: always sequential.  Splitting the num_patom^3 block loop with
     // rayon inside the nested-par call path regressed 46.92s -> 50.30s
     // on NaMgF3 128 threads (2026-04-21); each r0_average_block chunk is
@@ -84,7 +116,7 @@ fn real_to_normal(
     // single-triplet Python entry (py_real_to_reciprocal), which has
     // no outer par and genuinely benefits.
     real_to_reciprocal(
-        &mut fc3_reciprocal,
+        &mut scratch.fc3_reciprocal,
         &q_vecs,
         fc3,
         is_compact_fc3,
@@ -94,7 +126,7 @@ fn real_to_normal(
     reciprocal_to_normal_squared(
         fc3_normal_squared,
         g_pos,
-        &fc3_reciprocal,
+        &scratch.fc3_reciprocal,
         freqs0,
         freqs1,
         freqs2,
@@ -106,6 +138,7 @@ fn real_to_normal(
         num_patom,
         cutoff_frequency,
         inner_par,
+        &mut scratch.r2n,
     );
 }
 
@@ -130,6 +163,7 @@ fn real_to_normal_sym_q(
     num_patom: usize,
     cutoff_frequency: f64,
     inner_par: bool,
+    scratch: &mut InteractionScratch,
 ) {
     let num_band = num_patom * 3;
     let num_band0 = band_indices.len();
@@ -144,13 +178,18 @@ fn real_to_normal_sym_q(
     // mapping can route output into any band triple.
     let full_band_indices: Vec<i64> = (0..num_band as i64).collect();
     let full = build_full_g_pos(num_band);
-    let mut tmp = vec![0.0f64; num_band * num_band * num_band];
+    scratch
+        .sym_q_tmp
+        .resize(num_band * num_band * num_band, 0.0);
 
     for perm in INDEX_EXCHANGE.iter() {
         let mut q_vecs_ex = [[0.0f64; 3]; 3];
         for j in 0..3 {
             q_vecs_ex[j] = q_vecs[perm[j]];
         }
+        // Move tmp out of scratch so it can be borrowed mutably while
+        // the rest of scratch (fc3_reciprocal / r2n) is also borrowed.
+        let mut tmp = std::mem::take(&mut scratch.sym_q_tmp);
         real_to_normal(
             &mut tmp,
             &full,
@@ -169,6 +208,7 @@ fn real_to_normal_sym_q(
             num_patom,
             cutoff_frequency,
             inner_par,
+            scratch,
         );
 
         // Scatter tmp into fc3_normal_squared using band index exchange.
@@ -184,6 +224,8 @@ fn real_to_normal_sym_q(
             let dst_idx = band0 * num_band * num_band + k * num_band + l;
             fc3_normal_squared[dst_idx] += tmp[src_idx] / 6.0;
         }
+
+        scratch.sym_q_tmp = tmp;
     }
 }
 
@@ -223,10 +265,14 @@ pub fn get_interaction_at_triplet(
     symmetrize_fc3_q: bool,
     cutoff_frequency: f64,
     inner_par: bool,
+    scratch: &mut InteractionScratch,
 ) {
     let num_patom = num_band / 3;
     let q_vecs = compute_q_vecs(triplet, bz_grid_addresses, d_diag, q_mat);
-    let g_pos = set_g_pos(g_zero_triplet, num_band0, num_band);
+    // Move g_pos out of scratch so the rest of scratch can be borrowed
+    // mutably while g_pos is read by the kernels.  Restored at end.
+    let mut g_pos = std::mem::take(&mut scratch.g_pos);
+    set_g_pos(&mut g_pos, g_zero_triplet, num_band0, num_band);
 
     if symmetrize_fc3_q {
         let mut freqs_arr: [Vec<f64>; 3] = [
@@ -270,6 +316,7 @@ pub fn get_interaction_at_triplet(
             num_patom,
             cutoff_frequency,
             inner_par,
+            scratch,
         );
     } else {
         let base0 = triplet[0] as usize * num_band;
@@ -296,8 +343,11 @@ pub fn get_interaction_at_triplet(
             num_patom,
             cutoff_frequency,
             inner_par,
+            scratch,
         );
     }
+
+    scratch.g_pos = g_pos;
 }
 
 /// Main entry: port of `itr_get_interaction` in `c/interaction.c`.
@@ -339,7 +389,7 @@ pub fn get_interaction(
     fc3_normal_squared
         .par_chunks_mut(num_band_prod)
         .enumerate()
-        .for_each(|(i, slot)| {
+        .for_each_init(InteractionScratch::new, |scratch, (i, slot)| {
             let gz = &g_zero[i * num_band_prod..(i + 1) * num_band_prod];
             get_interaction_at_triplet(
                 slot,
@@ -360,6 +410,7 @@ pub fn get_interaction(
                 symmetrize_fc3_q,
                 cutoff_frequency,
                 inner_par,
+                scratch,
             );
         });
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1629,6 +1629,7 @@ fn py_reciprocal_to_normal_squared<'py>(
         .map_err(|_| PyValueError::new_err("fc3_normal_squared must be C-contiguous"))?;
 
     py.detach(|| {
+        let mut scratch = reciprocal_to_normal::R2NScratch::new();
         reciprocal_to_normal::reciprocal_to_normal_squared(
             out_slice,
             g_pos_slice,
@@ -1644,6 +1645,7 @@ fn py_reciprocal_to_normal_squared<'py>(
             num_patom,
             cutoff_frequency,
             true,
+            &mut scratch,
         );
     });
 
@@ -2243,6 +2245,25 @@ fn py_detailed_imag_self_energy_with_g<'py>(
 ///   / ``masses`` / ``p2s_map`` / ``s2p_map`` / ``band_indices``
 ///   / ``all_shortest``: same layouts as in ``interaction``.
 /// - ``temperatures_thz``: ``(num_temps,)`` ``float64``.
+/// Release the per-rayon-worker collision scratch back to the
+/// allocator.  Each rayon worker thread holds a ~250 MiB scratch (at
+/// num_patom = 56) for the lifetime of the process; this function
+/// drops them all.  The next ``pp_collision`` / ``collision_at_grid_point``
+/// call will lazily re-allocate.
+///
+/// Intended for memory-heavy follow-up steps (e.g. the LBTE kappa-solve
+/// diagonalization) that need every byte after the collision kernel
+/// has finished.  Must only be called when no Rust collision kernel
+/// is in flight; calling it from inside a rayon parallel context
+/// would deadlock.
+#[pyfunction]
+#[pyo3(name = "release_collision_scratch")]
+fn py_release_collision_scratch(py: Python<'_>) {
+    py.detach(|| {
+        pp_collision::release_scratch();
+    });
+}
+
 #[pyfunction]
 #[pyo3(name = "pp_collision")]
 #[allow(clippy::too_many_arguments)]
@@ -4717,6 +4738,7 @@ fn phono3py_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_imag_self_energy_with_g, m)?)?;
     m.add_function(wrap_pyfunction!(py_detailed_imag_self_energy_with_g, m)?)?;
     m.add_function(wrap_pyfunction!(py_interaction, m)?)?;
+    m.add_function(wrap_pyfunction!(py_release_collision_scratch, m)?)?;
     m.add_function(wrap_pyfunction!(py_pp_collision, m)?)?;
     m.add_function(wrap_pyfunction!(py_pp_collision_with_sigma, m)?)?;
     m.add_function(wrap_pyfunction!(py_collision_at_grid_point, m)?)?;

--- a/rust/src/pp_collision.rs
+++ b/rust/src/pp_collision.rs
@@ -8,11 +8,13 @@
 //! This mirrors `ppc_get_pp_collision` (tetrahedron method) and
 //! `ppc_get_pp_collision_with_sigma` (Gaussian smearing).
 
+use std::cell::RefCell;
+
 use rayon::prelude::*;
 
 use crate::common::Cmplx;
-use crate::imag_self_energy::{imag_self_energy_at_triplet, set_g_pos};
-use crate::interaction::get_interaction_at_triplet;
+use crate::imag_self_energy::imag_self_energy_at_triplet;
+use crate::interaction::{get_interaction_at_triplet, InteractionScratch};
 use crate::real_to_reciprocal::AtomTriplets;
 use crate::triplet::{is_n, set_relative_grid_address, RelativeGridAddress};
 use crate::triplet_iw::{
@@ -21,28 +23,76 @@ use crate::triplet_iw::{
 };
 
 /// Scratch buffers reused across triplets to avoid per-triplet heap
-/// churn.  One instance per rayon worker (or one total for the
-/// sequential path).
+/// churn.  Held in a thread-local cell (see `COLLISION_SCRATCH`) so
+/// each rayon worker thread allocates its ~250 MiB scratch (at
+/// num_patom = 56) once at first use and reuses it for the rest of
+/// the program lifetime, across all driver invocations and batches.
+/// Compared to `for_each_init`, this fixes the alloc count to
+/// `num_workers` rather than scaling with rayon's adaptive job
+/// split count.
+#[derive(Default)]
 struct CollisionScratch {
     fc3_normal_squared: Vec<f64>,
     g_buf: Vec<f64>,
     g_zero: Vec<i8>,
+    interaction: InteractionScratch,
 }
 
 impl CollisionScratch {
-    fn new(num_band_prod: usize) -> Self {
-        Self {
-            fc3_normal_squared: vec![0.0; num_band_prod],
-            g_buf: vec![0.0; 2 * num_band_prod],
-            g_zero: vec![0; num_band_prod],
-        }
-    }
-
-    fn reset(&mut self) {
+    /// Resize all per-triplet buffers to match the current shape and
+    /// zero them.  Called once per triplet at the top of the kernel.
+    /// Vec::resize is a no-op when the size is unchanged (the common
+    /// case after the first call on each worker), so amortized cost is
+    /// just the fill.
+    fn reset(&mut self, num_band_prod: usize) {
+        self.fc3_normal_squared.resize(num_band_prod, 0.0);
         self.fc3_normal_squared.fill(0.0);
+        self.g_buf.resize(2 * num_band_prod, 0.0);
         self.g_buf.fill(0.0);
+        self.g_zero.resize(num_band_prod, 0);
         self.g_zero.fill(0);
     }
+}
+
+thread_local! {
+    /// Per-rayon-worker persistent scratch.  `None` until first use on
+    /// each worker; populated lazily via `get_or_insert_with`.
+    static COLLISION_SCRATCH: RefCell<Option<CollisionScratch>> =
+        const { RefCell::new(None) };
+}
+
+/// Acquire the calling thread's `CollisionScratch`, run `f`, and
+/// release the borrow.  Panics if called recursively (which would
+/// indicate two collision kernels stacked on the same thread).
+fn with_scratch<F, R>(num_band_prod: usize, f: F) -> R
+where
+    F: FnOnce(&mut CollisionScratch) -> R,
+{
+    COLLISION_SCRATCH.with(|cell| {
+        let mut opt = cell.borrow_mut();
+        let scratch = opt.get_or_insert_with(CollisionScratch::default);
+        scratch.reset(num_band_prod);
+        f(scratch)
+    })
+}
+
+/// Release the per-rayon-worker `CollisionScratch` instances back to
+/// the allocator.  Visits every worker thread in the global rayon
+/// pool via `rayon::broadcast` and drops the held `Option<Scratch>`.
+///
+/// **Must not be called from inside a rayon parallel iterator** — it
+/// would deadlock waiting for workers that are themselves blocked
+/// inside the broadcast.  Intended to be called from Python after a
+/// collision kernel has returned, e.g. before LBTE's memory-heavy
+/// kappa-solve diagonalization, when the ~250 MiB-per-worker
+/// (num_patom = 56) scratch is no longer needed.  The next collision
+/// kernel will lazily re-allocate on first use.
+pub fn release_scratch() {
+    rayon::broadcast(|_ctx| {
+        COLLISION_SCRATCH.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+    });
 }
 
 /// Per-triplet evaluator: compute interaction, then imag-self-energy
@@ -77,6 +127,7 @@ fn evaluate_collision_at_triplet(
     symmetrize_fc3_q: bool,
     cutoff_frequency: f64,
     inner_par: bool,
+    interaction_scratch: &mut InteractionScratch,
 ) {
     let num_band_prod = num_band0 * num_band * num_band;
 
@@ -99,9 +150,13 @@ fn evaluate_collision_at_triplet(
         symmetrize_fc3_q,
         cutoff_frequency,
         inner_par,
+        interaction_scratch,
     );
 
-    let g_pos = set_g_pos(g_zero, num_band0, num_band);
+    // get_interaction_at_triplet has populated `interaction_scratch.g_pos`
+    // (writes via set_g_pos at entry, restores at exit).  Reuse it
+    // directly instead of re-running set_g_pos here.
+    let g_pos = interaction_scratch.g_pos.as_slice();
     let (g1, g2_3) = g_buf.split_at(num_band_prod);
 
     for (t, &temperature_thz) in temperatures_thz.iter().enumerate().take(num_temps) {
@@ -116,7 +171,7 @@ fn evaluate_collision_at_triplet(
             triplet_weight,
             g1,
             g2_3,
-            &g_pos,
+            g_pos,
             temperature_thz,
             cutoff_frequency,
             false,
@@ -213,7 +268,7 @@ pub fn get_pp_collision(
                    (i, ise_slot): (usize, &mut [f64])|
      -> Result<(), BzGridError> {
         let triplet = triplets[i];
-        scratch.reset();
+        // scratch already reset+sized by `with_scratch` wrapper.
         {
             let (g1_slot, g2_3_slot) = scratch.g_buf.split_at_mut(num_band_prod);
             let mut iw_ch: Vec<&mut [f64]> = vec![g1_slot, g2_3_slot];
@@ -256,6 +311,7 @@ pub fn get_pp_collision(
             symmetrize_fc3_q,
             cutoff_frequency,
             inner_par,
+            &mut scratch.interaction,
         );
         Ok(())
     };
@@ -263,7 +319,7 @@ pub fn get_pp_collision(
     ise_per_triplet
         .par_chunks_mut(per_triplet_stride)
         .enumerate()
-        .try_for_each_init(|| CollisionScratch::new(num_band_prod), run_one)?;
+        .try_for_each(|item| with_scratch(num_band_prod, |scratch| run_one(scratch, item)))?;
 
     finalize(
         collisions,
@@ -320,7 +376,7 @@ pub fn get_pp_collision_with_sigma(
 
     let run_one = |scratch: &mut CollisionScratch, (i, ise_slot): (usize, &mut [f64])| {
         let triplet = triplets[i];
-        scratch.reset();
+        // scratch already reset+sized by `with_scratch` wrapper.
         {
             let (g1_slot, g2_3_slot) = scratch.g_buf.split_at_mut(num_band_prod);
             let mut iw_ch: Vec<&mut [f64]> = vec![g1_slot, g2_3_slot];
@@ -361,13 +417,14 @@ pub fn get_pp_collision_with_sigma(
             symmetrize_fc3_q,
             cutoff_frequency,
             inner_par,
+            &mut scratch.interaction,
         );
     };
 
     ise_per_triplet
         .par_chunks_mut(per_triplet_stride)
         .enumerate()
-        .for_each_init(|| CollisionScratch::new(num_band_prod), run_one);
+        .for_each(|item| with_scratch(num_band_prod, |scratch| run_one(scratch, item)));
 
     finalize(
         collisions,
@@ -485,7 +542,7 @@ pub fn get_pp_collision_multi_gp(
      -> Result<(), BzGridError> {
         let (gp_idx, triplet, weight) = flat_work[flat_idx];
         let freqs_at_gp = &freqs_per_gp[gp_idx];
-        scratch.reset();
+        // scratch already reset+sized by `with_scratch` wrapper.
         {
             let (g1_slot, g2_3_slot) = scratch.g_buf.split_at_mut(num_band_prod);
             let mut iw_ch: Vec<&mut [f64]> = vec![g1_slot, g2_3_slot];
@@ -528,6 +585,7 @@ pub fn get_pp_collision_multi_gp(
             symmetrize_fc3_q,
             cutoff_frequency,
             false, // batched outer par saturates the pool; no inner par.
+            &mut scratch.interaction,
         );
         Ok(())
     };
@@ -535,7 +593,7 @@ pub fn get_pp_collision_multi_gp(
     ise_all
         .par_chunks_mut(per_triplet_stride)
         .enumerate()
-        .try_for_each_init(|| CollisionScratch::new(num_band_prod), run_one)?;
+        .try_for_each(|item| with_scratch(num_band_prod, |scratch| run_one(scratch, item)))?;
 
     // Per-gp finalize.  Sequential (cheap; finalize is a O(num_triplets *
     // per_triplet_stride) add-reduction, dwarfed by the kernel work).
@@ -633,7 +691,7 @@ pub fn get_pp_collision_with_sigma_multi_gp(
     let run_one = |scratch: &mut CollisionScratch, (flat_idx, ise_slot): (usize, &mut [f64])| {
         let (gp_idx, triplet, weight) = flat_work[flat_idx];
         let freqs_at_gp = &freqs_per_gp[gp_idx];
-        scratch.reset();
+        // scratch already reset+sized by `with_scratch` wrapper.
         {
             let (g1_slot, g2_3_slot) = scratch.g_buf.split_at_mut(num_band_prod);
             let mut iw_ch: Vec<&mut [f64]> = vec![g1_slot, g2_3_slot];
@@ -674,13 +732,14 @@ pub fn get_pp_collision_with_sigma_multi_gp(
             symmetrize_fc3_q,
             cutoff_frequency,
             false,
+            &mut scratch.interaction,
         );
     };
 
     ise_all
         .par_chunks_mut(per_triplet_stride)
         .enumerate()
-        .for_each_init(|| CollisionScratch::new(num_band_prod), run_one);
+        .for_each(|item| with_scratch(num_band_prod, |scratch| run_one(scratch, item)));
 
     let mut offset = 0usize;
     for g in 0..num_gps {

--- a/rust/src/reciprocal_to_normal.rs
+++ b/rust/src/reciprocal_to_normal.rs
@@ -29,6 +29,33 @@ impl<T> SyncMutPtr<T> {
     }
 }
 
+/// Per-call scratch for `reciprocal_to_normal_squared`.  Buffers are
+/// resized lazily on first use and reused on subsequent calls with the
+/// same shape.  Owned by the caller (typically a per-rayon-worker
+/// `for_each_init`) so that allocation cost is paid once per worker
+/// rather than once per triplet.
+#[derive(Default)]
+pub struct R2NScratch {
+    /// Eigenvectors at vertex 0, scaled by `1/sqrt(mass)` and transposed
+    /// to `[band, component]`.  Length `num_band * num_band`.
+    pub e0: Vec<Cmplx>,
+    /// Same as `e0` for vertex 1.
+    pub e1: Vec<Cmplx>,
+    /// Same as `e0` for vertex 2.
+    pub e2: Vec<Cmplx>,
+    /// Phase 1 cache `(num_band0, num_band, num_band)` flat.
+    pub fc3_e0: Vec<Cmplx>,
+    /// Phase 2 row buffer of length `num_band` (used only by the
+    /// `inner_par = false` branch).
+    pub row: Vec<Cmplx>,
+}
+
+impl R2NScratch {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 /// Pre-scale eigenvectors by `1 / sqrt(mass)` and transpose so the
 /// fast axis is the component axis (for a fixed band).
 ///
@@ -38,8 +65,8 @@ impl<T> SyncMutPtr<T> {
 /// Output layout: `out[band * num_band + component]`
 /// (`[band, component]` row-major), with each element multiplied by
 /// `1 / sqrt(masses[component / 3])`.
-fn scale_and_transpose(eigvecs: &[Cmplx], masses: &[f64], num_band: usize) -> Vec<Cmplx> {
-    let mut out = vec![[0.0f64; 2]; num_band * num_band];
+fn scale_and_transpose(out: &mut Vec<Cmplx>, eigvecs: &[Cmplx], masses: &[f64], num_band: usize) {
+    out.resize(num_band * num_band, [0.0f64; 2]);
     for comp in 0..num_band {
         let atom = comp / 3;
         let inv_sqrt_mass = 1.0 / masses[atom].sqrt();
@@ -48,7 +75,6 @@ fn scale_and_transpose(eigvecs: &[Cmplx], masses: &[f64], num_band: usize) -> Ve
             out[band * num_band + comp] = [src[0] * inv_sqrt_mass, src[1] * inv_sqrt_mass];
         }
     }
-    out
 }
 
 /// Contract fc3 with `e0` at a single target band and a single `b`
@@ -240,6 +266,7 @@ pub fn reciprocal_to_normal_squared(
     num_patom: usize,
     cutoff_frequency: f64,
     inner_par: bool,
+    scratch: &mut R2NScratch,
 ) {
     let num_band = num_patom * 3;
     debug_assert_eq!(fc3_reciprocal.len(), num_patom * num_patom * num_patom * 27);
@@ -251,9 +278,23 @@ pub fn reciprocal_to_normal_squared(
     debug_assert_eq!(freqs1.len(), num_band);
     debug_assert_eq!(freqs2.len(), num_band);
 
-    let e0 = scale_and_transpose(eigvecs0, masses, num_band);
-    let e1 = scale_and_transpose(eigvecs1, masses, num_band);
-    let e2 = scale_and_transpose(eigvecs2, masses, num_band);
+    // Destructure scratch up front so each field has its own mutable
+    // borrow.  This lets Phase 1's `&mut fc3_e0` coexist with Phase 2's
+    // `&mut row` (and with the immutable reads of `e0/e1/e2`) without
+    // tripping the borrow checker.
+    let R2NScratch {
+        e0,
+        e1,
+        e2,
+        fc3_e0,
+        row,
+    } = scratch;
+    scale_and_transpose(e0, eigvecs0, masses, num_band);
+    scale_and_transpose(e1, eigvecs1, masses, num_band);
+    scale_and_transpose(e2, eigvecs2, masses, num_band);
+    let e0: &[Cmplx] = e0.as_slice();
+    let e1: &[Cmplx] = e1.as_slice();
+    let e2: &[Cmplx] = e2.as_slice();
 
     // fc3_e0 caches the contraction over (a, l) at each target band0
     // index as a (num_band, num_band) band-pair matrix.  Shape:
@@ -261,7 +302,7 @@ pub fn reciprocal_to_normal_squared(
     // num_band * num_band (= num_patom * num_patom * 9).
     let num_band0 = band_indices.len();
     let entry_size = num_band * num_band;
-    let mut fc3_e0 = vec![[0.0f64; 2]; num_band0 * entry_size];
+    fc3_e0.resize(num_band0 * entry_size, [0.0f64; 2]);
 
     if inner_par {
         // Flat (band0, b) parallel axis: num_band0 * num_patom tasks
@@ -290,6 +331,11 @@ pub fn reciprocal_to_normal_squared(
         }
     }
 
+    // Downgrade fc3_e0 to a shared slice for Phase 2 so the par_iter
+    // closure captures by `&[Cmplx]` (Sync) instead of `&mut [Cmplx]`
+    // (not Sync).
+    let fc3_e0: &[Cmplx] = fc3_e0.as_slice();
+
     if inner_par {
         // SAFETY: each g_pos entry writes to a distinct `dest` index in
         // fc3_normal_squared (the caller's contract: g_pos encodes a
@@ -300,7 +346,7 @@ pub fn reciprocal_to_normal_squared(
         let out_ptr = SyncMutPtr(fc3_normal_squared.as_mut_ptr());
         g_pos.par_iter().for_each_init(
             || vec![[0.0f64; 2]; num_band],
-            |scratch, gp| {
+            |row_scratch, gp| {
                 let i0 = gp[0] as usize;
                 let j = gp[1] as usize;
                 let k = gp[2] as usize;
@@ -315,7 +361,7 @@ pub fn reciprocal_to_normal_squared(
                     let fc3_e0_entry = &fc3_e0[i0 * entry_size..(i0 + 1) * entry_size];
                     let e1_band = &e1[j * num_band..(j + 1) * num_band];
                     let e2_band = &e2[k * num_band..(k + 1) * num_band];
-                    let sq = get_fc3_sum_atomwise(fc3_e0_entry, e1_band, e2_band, scratch);
+                    let sq = get_fc3_sum_atomwise(fc3_e0_entry, e1_band, e2_band, row_scratch);
                     sq / (freqs0[bi] * freqs1[j] * freqs2[k])
                 };
                 unsafe {
@@ -324,9 +370,9 @@ pub fn reciprocal_to_normal_squared(
             },
         );
     } else {
-        // Scratch row buffer for get_fc3_sum_atomwise Phase 1; one
-        // allocation per reciprocal_to_normal_squared invocation.
-        let mut scratch = vec![[0.0f64; 2]; num_band];
+        // Phase 2 row buffer for get_fc3_sum_atomwise; reused across
+        // calls via the caller-provided scratch.
+        row.resize(num_band, [0.0f64; 2]);
         for gp in g_pos {
             let i0 = gp[0] as usize;
             let j = gp[1] as usize;
@@ -342,7 +388,7 @@ pub fn reciprocal_to_normal_squared(
                 let fc3_e0_entry = &fc3_e0[i0 * entry_size..(i0 + 1) * entry_size];
                 let e1_band = &e1[j * num_band..(j + 1) * num_band];
                 let e2_band = &e2[k * num_band..(k + 1) * num_band];
-                let sq = get_fc3_sum_atomwise(fc3_e0_entry, e1_band, e2_band, &mut scratch);
+                let sq = get_fc3_sum_atomwise(fc3_e0_entry, e1_band, e2_band, row);
                 sq / (freqs0[bi] * freqs1[j] * freqs2[k])
             };
             fc3_normal_squared[dest] = val;
@@ -370,7 +416,8 @@ mod tests {
         let num_band = 3;
         let eigvecs = make_identity_eigvecs(num_band);
         let masses = vec![1.0];
-        let out = scale_and_transpose(&eigvecs, &masses, num_band);
+        let mut out = Vec::new();
+        scale_and_transpose(&mut out, &eigvecs, &masses, num_band);
         for i in 0..num_band {
             for j in 0..num_band {
                 let expected = if i == j { [1.0, 0.0] } else { [0.0, 0.0] };
@@ -385,7 +432,8 @@ mod tests {
         let num_band = 3;
         let eigvecs = make_identity_eigvecs(num_band);
         let masses = vec![4.0];
-        let out = scale_and_transpose(&eigvecs, &masses, num_band);
+        let mut out = Vec::new();
+        scale_and_transpose(&mut out, &eigvecs, &masses, num_band);
         for i in 0..num_band {
             assert!((out[i * num_band + i][0] - 0.5).abs() < 1e-15);
             assert!(out[i * num_band + i][1].abs() < 1e-15);
@@ -409,6 +457,7 @@ mod tests {
             })
             .collect();
         let mut out = vec![1.0f64; band_indices.len() * num_band * num_band];
+        let mut scratch = R2NScratch::new();
         reciprocal_to_normal_squared(
             &mut out,
             &g_pos,
@@ -424,6 +473,7 @@ mod tests {
             num_patom,
             0.0,
             false,
+            &mut scratch,
         );
         for v in &out {
             assert_eq!(*v, 0.0);
@@ -450,6 +500,7 @@ mod tests {
         let band_indices = vec![0i64];
         let g_pos: Vec<[i64; 4]> = vec![[0, 0, 0, 0]];
 
+        let mut scratch = R2NScratch::new();
         let mut out = vec![-1.0f64; 1];
         reciprocal_to_normal_squared(
             &mut out,
@@ -466,6 +517,7 @@ mod tests {
             num_patom,
             0.5,
             false,
+            &mut scratch,
         );
         assert_eq!(out[0], 0.0);
 
@@ -485,6 +537,7 @@ mod tests {
             num_patom,
             0.5,
             false,
+            &mut scratch,
         );
         assert!(out[0] > 0.0);
     }


### PR DESCRIPTION
Avoid per-triplet heap allocation. Each triplet uses a fixed amount of scratch memory, so each rayon worker allocates its scratch once via thread_local! and reuses it across all triplets it processes. Total allocation: (per-triplet scratch) × (number of rayon worker threads). `phono3py_rs.release_collision_scratch()` is exposed for callers that need to release the per-rayon-worker scratch allocated in Rust before a memory-heavy follow-up step. Currently this is not done.
